### PR TITLE
feat: floating-point support via a typed ANF pipeline

### DIFF
--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -13,7 +13,7 @@ low / medium / high / godmode (the hardest research jumps).
 | 05 | [Effect/type inference over LLVM-IR](05-effect-inference.md) | research | high | godmode | proposed |
 | 06 | [Side effects via monadic metalanguage](06-monadic-effects-translation.md) | research | high | godmode | proposed |
 | 03 | [Widen the accepted LLVM-IR subset](03-broader-subset.md) | enhancement | medium | medium | done |
-| 09 | [Floating-point support (pure, two-type story)](09-floating-point.md) | enhancement | medium | medium | proposed |
+| 09 | [Floating-point support (pure, two-type story)](09-floating-point.md) | enhancement | medium | medium | done |
 | 10 | [i1-aware Bool (idiomatic boolean output)](10-boolean-types.md) | enhancement | low | medium | proposed |
 | 04 | [Annotated ANF AST with multiple backends](04-annotated-anf-ast.md) | refactor | medium | medium | proposed |
 | 07 | [Source-to-source optimizations on ANF](07-anf-optimizations.md) | research | low | high | proposed |

--- a/docs/roadmap/plans/09-floating-point.md
+++ b/docs/roadmap/plans/09-floating-point.md
@@ -11,17 +11,26 @@ Landed. A `src/TypeSystem.hs` module now carries the `Ty` lattice
 (`TyInt`/`TyFloat`/`TyDouble`/`TyBool`/`TyUnit`), the elaboration `elaborate`
 (total, errors off-subset — replacing the old silent `"Int"` fallback) and the
 representation map `rho`. `Anf` carries `Ty` instead of `String`; `ConvOp` carries
-source/target `Ty`; `Value` gained `FConst`. The `f*` arithmetic, `fcmp`
-(ordered + unordered predicates), the int↔float / float↔float conversions, float
-literals (decimal-exponent form) and the `nneg`/fast-math flag skips are all in.
-`TyBool` is wired but dormant (i1 still elaborates to `TyInt 1`), leaving #10 a
-localized switch as designed (§7).
+source/target `Ty`; the comparison node carries its operand `Ty`; `Value` gained
+`FConst`. The `f*` arithmetic (`fadd`/`fsub`/`fmul`/`fdiv`), `fcmp` (ordered +
+unordered predicates, **NaN-faithful** via `isNaN` guards — §5), the int↔float /
+float↔float conversions, float literals (decimal-exponent form) and the
+`nneg`/fast-math flag skips are all in. `TyBool` is wired but dormant (i1 still
+elaborates to `TyInt 1`), leaving #10 a localized switch as designed (§7).
 
 The six research-classic examples (`rump`, `muller`, `twosum`, `kahan_sum`,
 `newton_sqrt`, `logistic`) plus the type-system/codegen unit specs in
 `test/FloatingSpec.hs` are green, and the differential harness — extended for
-float signatures and **bit-pattern** comparison — certifies the whole corpus
-(26 functions) bit-for-bit exact against native clang, integer corpus included.
+float signatures, **bit-pattern** comparison and **NaN/±Inf** input sampling
+(with NaN-result canonicalisation) — certifies the whole corpus (26 functions)
+bit-for-bit exact against native clang, integer corpus included.
+
+Two review-driven corrections after the first cut: (1) `frem` was *removed* from
+the subset rather than mapped to `Data.Fixed.mod'`, whose floor semantics differ
+from C `fmod` (§11.1); (2) the unordered `fcmp` predicates and `one` were made
+NaN-faithful with `isNaN` guards instead of bare operators, which diverged on NaN
+inputs (the merged icmp/fcmp node now carries its operand `Ty` so integer `ugt`
+stays a plain `>` while float `ugt` is guarded).
 
 Deferred (matches §11 open decisions): hex IEEE float literals (corpus is all
 decimal), `ord`/`uno` NaN-test predicates, and the standalone `validate` pass
@@ -310,12 +319,18 @@ Inventory, with the typing rule each must satisfy (validated per §2):
   routinely picks the *unordered* predicate so that a NaN operand falls through
   to the negated branch (`!(a > 0)` must hold when `a` is NaN). So the minimum
   viable predicate set must include the unordered comparisons, not just the
-  ordered ones. On the **no-NaN** corpus the two collapse: with neither operand
-  NaN, `ugt` and `ogt` denote the same Haskell `>`, so both map to the natural
-  comparison and the differential harness certifies them identically. The only
-  genuinely separate cases are `ord`/`uno` (explicit NaN tests, `x == x` /
-  `x /= x`) — those remain the §11 open decision, since nothing in the corpus
-  emits them.
+  ordered ones. **They must be NaN-faithful, not merely "right on the no-NaN
+  domain":** an unordered predicate is `True` whenever an operand is NaN, but
+  Haskell's `<`/`>`/`==` return `False` on NaN, so each unordered relational and
+  `ueq` is emitted with an explicit `isNaN` guard
+  (`ugt` → `isNaN a || isNaN b || a > b`), and the ordered `one` (false unless
+  both operands are ordered) as `a == a && b == b && a /= b`. The ordered
+  relationals (`o*`) and `une` already coincide with the bare Haskell operators.
+  This is why the comparison node carries its *operand* `Ty` (§6.2): the same
+  spelling `ugt` is an unsigned-integer compare under `icmp` (plain `>`) and an
+  unordered float compare under `fcmp` (`isNaN`-guarded), and only the operand
+  sort tells them apart. `ord`/`uno` (explicit `x == x` / `x /= x` NaN tests)
+  remain the §11 open decision, since nothing in the corpus emits them.
 - **Int↔float conversions:** `sitofp uitofp fptosi fptoui` (§4).
 - **Float↔float conversions:** `fpext fptrunc` (§4).
 - **Literals:** `float`/`double` constants in LLVM's decimal-exponent form
@@ -554,8 +569,13 @@ Suggested sources (cover every §5 row):
 
 ## 11. Open decisions for the author
 
-1. **`frem` semantics.** Map to `Data.Fixed.mod'` and certify, or declare
-   out-of-subset? (C `fmod` vs `mod'` agreement needs a harness check.)
+1. **`frem` semantics.** *Resolved: out-of-subset.* `Data.Fixed.mod'` is
+   floor-based (result takes the divisor's sign), but `frem`/C `fmod` truncates
+   the quotient toward zero (result takes the dividend's sign) — e.g.
+   `fmod(-5,3) = -2` vs `mod' (-5) 3 = 1`. No *pure* Haskell primitive matches
+   `fmod` bit-exactly (the naive `a - b*truncate(a/b)` carries rounding error),
+   so `frem` is rejected rather than mapped wrongly; a faithful version would
+   need an FFI `fmod`. It appears nowhere in the corpus.
 2. **`ord`/`uno` (explicit NaN tests) only.** *Settled for the rest:* the
    ordered **and** unordered relational predicates are both required — the corpus
    forces it (`newton_sqrt.ll` emits `fcmp ugt`, §5), and on the no-NaN corpus

--- a/docs/roadmap/plans/09-floating-point.md
+++ b/docs/roadmap/plans/09-floating-point.md
@@ -1,0 +1,587 @@
+---
+type: plan
+title: Implementation plan — floating-point support and the type discipline it forces
+tracks: 09-floating-point.md
+status: done
+---
+
+## Outcome
+
+Landed. A `src/TypeSystem.hs` module now carries the `Ty` lattice
+(`TyInt`/`TyFloat`/`TyDouble`/`TyBool`/`TyUnit`), the elaboration `elaborate`
+(total, errors off-subset — replacing the old silent `"Int"` fallback) and the
+representation map `rho`. `Anf` carries `Ty` instead of `String`; `ConvOp` carries
+source/target `Ty`; `Value` gained `FConst`. The `f*` arithmetic, `fcmp`
+(ordered + unordered predicates), the int↔float / float↔float conversions, float
+literals (decimal-exponent form) and the `nneg`/fast-math flag skips are all in.
+`TyBool` is wired but dormant (i1 still elaborates to `TyInt 1`), leaving #10 a
+localized switch as designed (§7).
+
+The six research-classic examples (`rump`, `muller`, `twosum`, `kahan_sum`,
+`newton_sqrt`, `logistic`) plus the type-system/codegen unit specs in
+`test/FloatingSpec.hs` are green, and the differential harness — extended for
+float signatures and **bit-pattern** comparison — certifies the whole corpus
+(26 functions) bit-for-bit exact against native clang, integer corpus included.
+
+Deferred (matches §11 open decisions): hex IEEE float literals (corpus is all
+decimal), `ord`/`uno` NaN-test predicates, and the standalone `validate` pass
+(types are recoverable locally, so a global Γ was not needed for correctness).
+A pre-existing lexer gap surfaced and was fixed: named block labels with dots
+(`for.cond.cleanup:`) now lex (the integer corpus only used numeric labels).
+---
+
+# Floating point — implementation plan
+
+Tracks [`../09-floating-point.md`](../09-floating-point.md). Goal: accept the
+*pure* floating-point fragment of LLVM-IR (`float`/`double` and the `f*`
+instruction family) and translate it faithfully into Haskell `Float`/`Double`.
+
+This is **not** a table-rows job like [`03-broader-subset`](03-broader-subset.md).
+Floating point is the first feature that breaks the invariant that *every value
+is an integer*, an assumption baked into `Translate`, `PrintAnf`, and the
+string-typed `Anf` AST. Removing it requires giving the compiler a real, if
+small, **type system**: a type lattice, an environment, an elaboration +
+validation pass, and a coercion calculus at the boundaries between
+representations. The whole point of this plan is to introduce that machinery
+*once*, correctly, and in a shape that the next item —
+[`10-boolean-types`](../10-boolean-types.md) — drops into with almost no new
+code. Because the paper will need to model this mathematically, the plan states
+the type system formally (§2–§4) before the engineering (§5 onward).
+
+---
+
+## 1. Where the current design stops being enough
+
+Today "types" are threaded as **bare `String`s** and resolved *locally* at each
+binding:
+
+- `Anf.Decl` carries the result type as a `String` (`"Int32"`), and
+  `Anf.ConvOp` carries two `Int` widths. There are no other type slots.
+- `TranslateAux.hsTypeOfLlvm :: String -> String` maps an LLVM spelling to a
+  Haskell type spelling, and — critically — **silently defaults anything it does
+  not recognise to `"Int"`** (`src/TranslateAux.hs:105`). That is sound only
+  because the accepted subset is integer-only; the moment `float` enters, that
+  default is a *miscompile*, not an error.
+- `PrintAnf` hard-codes integer assumptions: `icmp` renders as
+  `if a < b then 1 else 0`, `select`'s condition as `a /= 0`, branch conditions
+  as `v /= 0`, and binary operators come from a type-blind
+  `translateOperator :: String -> String` (`add`→`+`, `sdiv`→`` `quot` ``).
+
+[`02-bit-width-fidelity`](02-bit-width-fidelity.md) got away with local,
+string-level typing because **LLVM-IR is already a fully, explicitly typed IR**:
+every instruction re-annotates the type of its operands and result at the use
+site (`%z = add i32 %x, %y`). We never needed to *infer* anything; we read what
+LLVM wrote. That observation survives into this plan and shapes the whole
+approach — see §2.
+
+What changes is that the *target* representation is no longer a single sort.
+Once values can be `IntK`, `Float`, or `Double` (and, in #10, `Bool`),
+operator spelling, comparison spelling, the condition forms, and — above all —
+the conversions at type boundaries all become **type-directed**. A `String`
+cannot direct them; a `Ty` can.
+
+---
+
+## 2. Theoretical foundation: elaboration and validation, not inference
+
+LLVM-IR in the accepted subset is a **monomorphic, explicitly typed** language.
+Every SSA value has exactly one statically-known type, written at its definition
+and repeated at every use. Two consequences drive the design:
+
+1. **We do not run Hindley–Milner.** There are no type variables to solve. The
+   "type system" is an *elaboration* (read LLVM's annotations into an internal
+   datatype) composed with a *validation* (check each instruction against
+   LLVM's typing rules). Validation is what upgrades today's silent `"Int"`
+   fallback into a total function with explicit out-of-subset errors — a
+   soundness improvement independent of floats.
+
+2. **Type information is recoverable per instruction**, but a handful of
+   positions in LLVM elide it: the condition of `br i1 %c, …` does not restate
+   `%c`'s type, nor does `select`'s use of its condition, nor a φ-incoming value
+   referenced from a predecessor. To type those uniformly we build a small
+   **typing environment** Γ once per function. SSA guarantees each name is
+   assigned exactly once, so Γ is a total function on the function's value names
+   and can be built by a single pass over all definitions.
+
+### 2.1 The type lattice
+
+Introduce a first-class type, replacing the `String`s:
+
+```haskell
+-- src/TypeSystem.hs  (new module)
+data Ty
+  = TyInt  Int   -- iN; carries the *LLVM* width N (1..64 in subset); rep rounding deferred to ρ
+  | TyFloat      -- LLVM `float`  — IEEE-754 binary32 — Haskell Float
+  | TyDouble     -- LLVM `double` — IEEE-754 binary64 — Haskell Double
+  | TyBool       -- i1-as-Bool. Wired in now, *dormant* until #10 (see §7).
+  | TyUnit       -- LLVM `void`
+  deriving (Eq, Show)
+```
+
+Carrying the *LLVM* width `N` (not the rounded-up representation width) keeps the
+type faithful to the source and defers the rounding decision to ρ, exactly where
+[`02-bit-width-fidelity`](02-bit-width-fidelity.md) already puts it. We also
+introduce the notion of a **sort** (integer / floating / boolean / unit) used by
+the validation rules:
+
+> sort(TyInt _) = ℤ  · sort(TyFloat)=sort(TyDouble) = 𝔽 · sort(TyBool)=𝔹 · sort(TyUnit)=𝟙
+
+### 2.2 The representation map ρ : Ty → Haskell
+
+ρ is the generalisation of today's `hsTypeOfLlvm` ∘ `widthToHsType`. It is
+**total over the lattice** and is the *only* place a `Ty` becomes a Haskell type
+string:
+
+| τ            | ρ(τ)                              | note |
+|--------------|-----------------------------------|------|
+| `TyInt N`    | `IntK`, K = roundUp(N) ∈ {8,16,32,64} | existing #02 map; N>64 ⇒ error |
+| `TyFloat`    | `Float`                           | IEEE binary32 |
+| `TyDouble`   | `Double`                          | IEEE binary64 |
+| `TyBool`     | `Bool`                            | dormant until #10 |
+| `TyUnit`     | `()`                              | existing void→unit (#08) |
+
+### 2.3 Elaboration ⌈·⌉ : LLVM type spelling → Ty
+
+A total function `elaborate :: String -> Ty` that *fails loudly* off-subset
+(replacing the `"Int"` default):
+
+```
+⌈"iN"⌉   = TyInt N           ⌈"float"⌉  = TyFloat
+⌈"void"⌉ = TyUnit            ⌈"double"⌉ = TyDouble
+⌈"half" | "fp128" | "ptr" | …⌉ = error "out of subset: <t>"
+```
+
+Note `i1` still elaborates to `TyInt 1` under this plan, **not** `TyBool` — the
+i1→Bool refinement is #10's single, localized switch (§7).
+
+---
+
+## 3. The typing judgement for the ANF metalanguage
+
+For the paper we give a declarative type system for the emitted ANF fragment and
+prove the translation lands inside it. Let Γ range over finite maps from value
+names to `Ty`. Constants are typed against an expected type (LLVM constants are
+untyped literals given meaning by their context, exactly as in LLVM-IR), so the
+judgement for values is bidirectional in the constant case:
+
+```
+─────────────────  (T-Var)        ─────────────────────  (T-IConst)
+Γ ⊢ x : Γ(x)                       Γ ⊢ (n : ℤ) ⇐ TyInt N
+
+────────────────────  (T-FConst)        ───────────────────  (T-Unit)
+Γ ⊢ (r : ℝ) ⇐ TyFloat|TyDouble          Γ ⊢ () : TyUnit
+```
+
+Instruction rules (⊕ ranges over arithmetic binops, ⋈ over comparisons):
+
+```
+ Γ⊢a:τ   Γ⊢b:τ   sort(τ)∈{ℤ,𝔽}            Γ⊢a:τ  Γ⊢b:τ   sort(τ)∈{ℤ,𝔽}
+ ─────────────────────────────  (T-Bin)   ───────────────────────────────  (T-Cmp)
+        Γ ⊢ a ⊕τ b : τ                          Γ ⊢ a ⋈τ b : TyInt 1†
+
+ Γ⊢c:κ  Γ⊢a:τ  Γ⊢b:τ   κ∈{TyInt 1,TyBool}      Γ ⊢ a : σ    coerce σ τ defined
+ ──────────────────────────────────────  (T-Sel)  ──────────────────────────────  (T-Conv)
+        Γ ⊢ select c a b : τ                          Γ ⊢ ⟨σ→τ⟩ a : τ
+```
+
+† Under #10 the result of T-Cmp becomes `TyBool`; that is the *only* rule that
+changes. (See §7.)
+
+The φ/control rules tie blocks together: a block translated as a λ has parameter
+types given by its φ-nodes' declared types, and every branch into it is a
+tail-call whose argument types must match those parameters — this is precisely
+the SSA→ANF correspondence the project already implements structurally, now
+*typed*:
+
+```
+ block B has φ-params (p₁:τ₁ … pₖ:τₖ)     each predecessor P supplies
+ a tail call B(v₁…vₖ) with Γ_P ⊢ vᵢ : τᵢ
+ ────────────────────────────────────────────────────────────────────  (T-Phi/Br)
+                 λ(p₁…pₖ). … : τ₁ → … → τₖ → τ_ret
+```
+
+### 3.1 Type-preservation theorem
+
+> **Theorem (F is type-preserving).** Let `f` be an LLVM-IR function in the
+> accepted subset, well-typed under LLVM's own type system with signature
+> `τ₁,…,τₙ → τ_r`. Then `F(f)` is a closed ANF term and
+> `⊢ F(f) : ρ(⌈τ₁⌉) → … → ρ(⌈τₙ⌉) → ρ(⌈τ_r⌉)`.
+
+*Proof sketch.* Structural induction over the dominator-tree walk
+(`anfFromTree`). Each LLVM instruction is well-typed under LLVM's rules by
+hypothesis; `elaborate` maps its annotated operand/result types into `Ty`, and
+each translation clause (`anfBinOp`, `anfIcmp`, `anfConvOp`, …) produces exactly
+the ANF former whose typing rule above has matching premises — the *validation*
+pass (§2) is what discharges those premises before emission. φ-parameter and
+tail-call types coincide by (T-Phi/Br) because the project resolves a branch's
+arguments from the *target* block's φ-nodes (`getValueForCurrentLabel`), whose
+declared types are the λ's parameter types. The representation map ρ is applied
+uniformly at print time, so the emitted Haskell signature is
+ρ ∘ ⌈·⌉ of the LLVM signature. ∎
+
+### 3.2 Semantic adequacy and the IEEE caveats
+
+Type preservation is the structural half; for the paper we also state the
+semantic half and its honest boundaries:
+
+> **Adequacy (informal).** For inputs in the representable domain,
+> `⟦F(f)⟧ = ⟦f⟧`.
+
+For the integer fragment this is the bit-width result already certified by the
+differential harness. For the floating fragment it rests on three facts that
+must be stated as *assumptions*, because they are where faithfulness can leak:
+
+1. **Format match.** Haskell `Float`/`Double` are IEEE-754 binary32/binary64,
+   the same formats as LLVM `float`/`double`; GHC lowers `+ - * /` to the
+   platform FPU, as clang does. So `fadd`/`fsub`/`fmul`/`fdiv` agree bit-for-bit
+   under the default rounding mode (round-to-nearest-even).
+2. **No fast-math.** LLVM `fast`/`nnan`/`ninf`/`reassoc` flags license
+   non-IEEE rearrangement. We **skip** these flags in the lexer (as we already
+   skip `nsw`), and the subset is therefore the *strict-FP* fragment. This is a
+   documented limitation, not a bug.
+3. **Conversion rounding direction.** `fptosi`/`fptoui` are
+   **round-toward-zero** in LLVM, so they map to Haskell `truncate`, *never*
+   `round`. (§4.) Getting this wrong is the classic floating-conversion
+   miscompile.
+
+`frem` is C's `fmod` (not Haskell's `Prelude.mod`); it maps to
+`Foreign.C` style `c_fmod` semantics, available as
+`Data.Fixed.mod'` for `RealFrac` — verify bit-exactness in the harness or
+declare `frem` out of scope if it diverges (open decision, §11).
+
+---
+
+## 4. The coercion calculus — the one mechanism that serves floats *and* Bool
+
+Every place two representations meet is mediated by a single partial function
+
+```
+coerce :: Ty -> Ty -> (Value -> String)      -- source Ty, target Ty, Haskell text
+```
+
+The LLVM conversion instructions are *names for entries in this table*; so is the
+implicit i1↔int coercion that #10 will need. Defining the table once is what
+makes Bool a near-free follow-up.
+
+| LLVM conv | σ → τ                | `coerce σ τ x` (Haskell)                                  | semantic note |
+|-----------|----------------------|-----------------------------------------------------------|---------------|
+| `trunc`   | `iN → iM` (N>M)      | `fromIntegral x :: IntM`                                  | wraps (existing #02) |
+| `zext`    | `iN → iM`            | `fromIntegral (fromIntegral x :: WordN) :: IntM`          | zero-extend (existing #02) |
+| `sext`    | `iN → iM`            | `fromIntegral x :: IntM`                                  | sign-extend (existing #02) |
+| `sitofp`  | `iN → fp`           | `fromIntegral x :: ρ(fp)`                                 | signed int→float |
+| `uitofp`  | `iN → fp`           | `fromIntegral (fromIntegral x :: WordN) :: ρ(fp)`         | unsigned int→float |
+| `fptosi`  | `fp → iN`           | `truncate x :: IntN`                                     | **round toward zero** |
+| `fptoui`  | `fp → iN`           | `fromIntegral (truncate x :: WordN) :: IntN`            | toward zero, via Word |
+| `fpext`   | `float → double`     | `GHC.Float.float2Double x`                               | exact widen |
+| `fptrunc` | `double → float`     | `GHC.Float.double2Float x`                               | rounds |
+| *(#10)*   | `i1/Bool → iN`       | `if x then 1 else 0 :: IntN`  (`zext i1`)                | Bool→int |
+| *(#10)*   | `iN → Bool`          | `x /= 0`                                                  | int→Bool (cond use) |
+
+Notes that must not be gotten wrong:
+- Use `GHC.Float.float2Double` / `double2Float` rather than `realToFrac` for
+  `fpext`/`fptrunc`: `realToFrac` routes through `Rational` on some GHCs and is
+  lossy/odd around NaN; the `GHC.Float` primitives are the bit-exact lowering.
+- `coerce` is **partial**; an undefined pair (e.g. `double → double` requested,
+  or a sortless conversion) is a validation error, surfacing malformed input
+  instead of emitting garbage.
+
+The arithmetic/comparison spellings likewise become **type-indexed**:
+
+```
+op⊕ :: Ty -> String      -- add↦"+", sdiv↦"`quot`", fdiv↦"/", fadd↦"+", frem↦"`mod'`", …
+op⋈ :: Ty -> String      -- icmp slt↦"<"; fcmp olt↦"<"; fcmp one↦"/="; …
+```
+
+For `+ - *` the spelling coincides across ℤ and 𝔽 (Haskell `Num`), but division,
+remainder, and *every comparison* differ, and the `f*` mnemonics are distinct
+tokens — so the dispatch must key on `Ty`, not on the bare mnemonic.
+
+---
+
+## 5. The LLVM floating surface to support
+
+Inventory, with the typing rule each must satisfy (validated per §2):
+
+- **Arith:** `fadd fsub fmul fdiv frem` — `fp → fp → fp` (T-Bin, sort 𝔽).
+- **Compare:** `fcmp <pred>` — `fp → fp → i1` (T-Cmp). Ordered/unordered
+  predicates: `oeq ogt oge olt ole one ord` and `ueq ugt uge ult ule une uno`.
+  **The unordered set is not optional.** The corpus (`newton_sqrt.ll`) shows
+  clang lowering an ordinary C `a <= 0.0` guard to `fcmp ugt` — i.e. clang
+  routinely picks the *unordered* predicate so that a NaN operand falls through
+  to the negated branch (`!(a > 0)` must hold when `a` is NaN). So the minimum
+  viable predicate set must include the unordered comparisons, not just the
+  ordered ones. On the **no-NaN** corpus the two collapse: with neither operand
+  NaN, `ugt` and `ogt` denote the same Haskell `>`, so both map to the natural
+  comparison and the differential harness certifies them identically. The only
+  genuinely separate cases are `ord`/`uno` (explicit NaN tests, `x == x` /
+  `x /= x`) — those remain the §11 open decision, since nothing in the corpus
+  emits them.
+- **Int↔float conversions:** `sitofp uitofp fptosi fptoui` (§4).
+- **Float↔float conversions:** `fpext fptrunc` (§4).
+- **Literals:** `float`/`double` constants in LLVM's decimal-exponent form
+  (`1.500000e+00`) and hexadecimal IEEE form (`double 0x4008000000000000`).
+  See §6.4 — this is its own sub-task.
+
+Out of scope (state explicitly): `half`/`fp128`, vector FP, FP intrinsics
+(`llvm.sqrt`, `llvm.fma`, …) beyond what the corpus needs, and all fast-math
+fragments.
+
+---
+
+## 6. Implementation, file by file
+
+The unifying move: **replace the `String` type slots in `Anf` with `Ty`**, route
+all of `Translate` through `elaborate`, and make `TranslateAux`/`PrintAnf`
+type-directed. This is also a down payment on
+[`04-annotated-anf-ast`](../04-annotated-anf-ast.md) (typed annotation slots) —
+worth calling out in the paper as the refactor that item formalises.
+
+### 6.1 New module `src/TypeSystem.hs`
+
+Home of the §2–§4 machinery, kept separate so `Translate` stays a syntax-directed
+walk and the theory has a 1:1 code home:
+
+- `data Ty` (§2.1) and `data Sort`; `sortOf :: Ty -> Sort`.
+- `elaborate :: String -> Ty` (§2.3), total, errors off-subset.
+- `rho :: Ty -> String` (§2.2) — supersedes `hsTypeOfLlvm`/`widthToHsType`
+  (move those here or re-express them through `rho`).
+- `coerce :: Ty -> Ty -> Value -> String` (§4), partial with explicit errors.
+- `opArith :: Ty -> String -> String`, `opCmp :: Ty -> String -> String`
+  (type-indexed §4 spellings) — supersede `translateOperator`/`translateCmpType`.
+- `type Gamma = Data.Map.Map String Ty`; `buildGamma :: Ast.Function Range ->
+  Gamma` (one pass over every definition: args, φ-nodes, and each `Dec`'s
+  result), plus `validate :: Gamma -> Ast.Function Range -> Either TypeError ()`
+  applying the §3 rules. `validate` is run by `translate` before emission; a
+  `Left` aborts with a clear message (the soundness upgrade over the silent
+  `"Int"`).
+
+### 6.2 `src/Anf.hs` — types become `Ty`, not `String`
+
+- Replace the result-type `String` on `DeclBinOp/DeclCall/DeclIcmp/DeclSelect/
+  DeclFreeze` with `Ty`.
+- Generalise `ConvOp String Int Int Value` to `ConvOp ConvKind Ty Ty Value`
+  carrying **source and target `Ty`** (not widths) — conversions now cross sorts,
+  so widths alone are insufficient. (`ConvKind` = the LLVM op name or an enum.)
+- The `Function` arg-types/return-type fields become `[Ty]` / `Ty`.
+- Add a floating constant to `Value`: `FConst Rational Ty` (keep the precise
+  value as `Rational` plus the intended `Ty` so the printer chooses `Float` vs
+  `Double` and a round-tripping literal). `Const Integer` stays for ints.
+
+### 6.3 `src/Lexer.x`
+
+- `float`/`double` already lex as `Type` (`src/Lexer.x:92`) — good, no change for
+  the type tokens.
+- Add the `f*` arithmetic mnemonics as `BinOp` tokens: `fadd fsub fmul fdiv frem`.
+- Add `fcmp` (its own token, parallel to `icmp`) and its predicate set to the
+  `Cmp` rule (extend the alternation at `src/Lexer.x:101`). The set **must
+  include the unordered predicates** (`ueq ugt uge ult ule une`), not just the
+  ordered ones: `newton_sqrt.ll` already emits `fcmp ugt` for a plain `a <= 0.0`
+  guard (see §5). The existing `Cmp` token spellings (`ugt ult …`) are reused by
+  the integer `icmp` and FP `fcmp` alike — they only differ in operand sort,
+  which the type system already tracks.
+- Add the FP conversions as `ConvOp` tokens: `sitofp uitofp fptosi fptoui fpext
+  fptrunc`.
+- **Skip `nneg`.** Clang tags `uitofp`/`zext` results that are provably
+  non-negative with the `nneg` flag (`kahan_sum.ll` emits `uitofp nneg i32 …`);
+  it is a non-semantic hint, so drop it in the lexer exactly as `nsw`/`nuw` are
+  already dropped — otherwise it lands between the op and its type and breaks the
+  conv-op production.
+- **Float literals** (§6.4): a new token rule for decimal-exponent and `0x…`
+  hex IEEE forms. Skip fast-math flag keywords (`fast nnan ninf nsz arcp
+  contract reassoc afn`) the way `nsw`/`nuw` are already dropped. (The corpus is
+  compiled `-ffp-contract=off`, so none of these appear in it — but a hand-written
+  or differently-compiled `.ll` may carry them.)
+
+### 6.4 Float literals — its own careful sub-task
+
+LLVM prints FP constants two ways:
+- **Decimal/exponential:** `1.500000e+00`, `-3.000000e+00`.
+- **Hex IEEE bit-pattern:** `0x4008000000000000` (and the `0xK/L/M/H` tagged
+  forms for `x86_fp80`/`fp128`/`half` — out of subset, error on those tags).
+
+Plan:
+- Lexer produces the raw lexeme; a parser/elaborator helper `parseFpLit ::
+  Ty -> String -> Rational` interprets it: decimal via `read`/`readFloat`; the
+  `0x…` form by reading 64 bits and `castWord64ToDouble`
+  (`GHC.Float`/`Data.Word`), then to `Rational`. For `float` literals LLVM still
+  prints the value widened to the `double` hex; convert to `Float` then store.
+- `value` production (`src/Parser.y:150`) gains a `fpLit` alternative; `Ast.Value`
+  gains a floating constructor mirroring `IntegerValue`.
+- Printing: emit a Haskell literal that round-trips bit-exactly. `show (d ::
+  Double)` is round-trip-faithful in GHC (shortest decimal s.t. `read . show =
+  id`), so emit `show v :: Double` / `:: Float`. Verify in the harness via
+  bit-pattern comparison (§8), not decimal eyeballing.
+
+### 6.5 `src/Parser.y`
+
+- Token decls for the new lexer tokens; `fcmp` production paralleling `icmp`
+  (`src/Parser.y:193`) building an `Ast.Fcmp` (or reuse `Icmp` with a flag — but
+  a distinct node keeps the validation rules clean; recommend a sibling node).
+- `binOpCall` already generic over the `BinOp` token, so `f*` arithmetic needs no
+  new production — only the lexer tokens and the type-indexed spelling in
+  `opArith`.
+- `convOperation` (`src/Parser.y:212`) already carries both source and target
+  `typeAnotation`; the FP conversions parse with no grammar change — only new
+  `ConvOp` tokens.
+- `value`/`Ast.Value` extended for FP literals (§6.4).
+
+### 6.6 `src/Translate.hs`
+
+- Run `buildGamma` + `validate` (§6.1) at the top of `translateFunction`;
+  thread `Gamma` into the block walk so condition/φ-incoming uses can be typed.
+- Replace every `typeStr`/`hsTypeOfLlvm` call with `elaborate` producing a `Ty`
+  that is stored in the `Anf` nodes (no longer a `String`).
+- `anfConvOp`: build `Anf.ConvOp` from the two elaborated `Ty`s (and the op kind)
+  instead of two widths.
+- `anfIcmp`/new `anfFcmp`: the result type stays `TyInt 1` for #09 (dormant Bool
+  seam, §7).
+- Float-constant operands flow through `anfValue` into the new `Value`
+  constructor.
+
+### 6.7 `src/TranslateAux.hs`
+
+- Demote `translateOperator`/`translateCmpType`/`hsTypeOfLlvm`/`widthToHsType`/
+  `widthToWordType` in favour of the `TypeSystem` exports (`opArith`/`opCmp`/
+  `rho`/`coerce`). Keep `widthToWordType` as a helper used by `coerce`.
+
+### 6.8 `src/PrintAnf.hs`
+
+- `annot`/`declString` consume `Ty` and call `rho`.
+- `printConvOp` becomes a thin call to `coerce src tgt value` (it already
+  special-cases `zext`; that logic moves into the `coerce` table).
+- `printBinOp` keys the operator on the operand `Ty` via `opArith` (the operands'
+  `Ty` is available from the decl's result `Ty` for same-sort binops; for safety
+  consult `Gamma` — pass the operand `Ty` into the node at translate time so the
+  printer stays Γ-free). The shift-amount `fromIntegral` coercion stays for the
+  integer shifts.
+- `printIcmp` stays integer (`if a < b then 1 else 0`) for #09; **`printFcmp`**
+  emits the same shape with `opCmp TyFloat`/`TyDouble` spelling. (#10 collapses
+  both to a bare `Bool` form — §7.)
+- Header imports: add `GHC.Float` (for `float2Double`/`double2Float`) and, if
+  `frem` is supported, `Data.Fixed`.
+
+---
+
+## 7. How Bool (#10) drops in — the forward-compatibility contract
+
+The deliverable promise of this plan is that
+[`10-boolean-types`](../10-boolean-types.md) needs **no new machinery**, only
+flips already-built switches. After #09 lands, #10 is exactly:
+
+1. **`elaborate "i1" = TyBool`** instead of `TyInt 1` (one line in §2.3).
+2. **T-Cmp result = `TyBool`** — change `anfIcmp`/`anfFcmp` to tag the result
+   `TyBool` (the dagger † in §3).
+3. **Two `coerce` rows activate** (already tabulated in §4): `Bool→iN` for the
+   `zext i1` clang emits, and `iN→Bool` for any residual integer-as-condition.
+4. **Condition forms simplify**: `printIcmp`/branch/`select` drop the
+   `then 1 else 0` / `/= 0` scaffolding because the condition is already `Bool`
+   (these become `rho`-driven: `Bool` conditions print bare, integer conditions
+   keep `/= 0`).
+5. **ρ(TyBool) = "Bool"** — already in §2.2.
+
+That is the entire #10 diff. Nothing in `Translate`'s structure, the grammar, or
+the coercion mechanism changes — which is the test that this plan got the
+abstraction boundary right. Keep `TyBool` in the lattice from day one (exported,
+so `-Wall` is quiet) precisely so #10 is a refinement, not a refactor.
+
+---
+
+## 8. Differential harness (`test/differential/run.py`)
+
+Today the harness assumes integer signatures: it skips any function whose
+signature has a non-int type (`run.py:140`), reads args with `strtoll`, prints
+`(long long)` on the C side and `fromIntegral … :: Integer` on the Haskell side
+(`run.py:157`, `:196`). Floating support means:
+
+- **Type-directed sampling.** Extend `CTYPE`/sampler maps with `float`/`double`;
+  generate finite, non-NaN/non-Inf float samples (and a few edge values: ±0,
+  subnormal, large-magnitude) per arg type.
+- **Bit-exact comparison, not decimal.** Printing floats as decimal risks
+  off-by-an-ULP false mismatches. Compare the **raw IEEE bit pattern** from both
+  sides: C prints the `uint64_t`/`uint32_t` reinterpretation of the result
+  (`memcpy` + `%llu`/`%u`, or `%a` hex-float); Haskell prints
+  `castDoubleToWord64`/`castFloatToWord32` (`GHC.Float`). Equal bit patterns ⇒
+  certified exact; this is also NaN-robust (bit-identical NaNs compare equal).
+- **Stop skipping FP signatures** once the path exists, so new FP examples are
+  certified by the same gate as the integer corpus.
+
+Document in `run.py`'s header that the certification covers the **strict-FP**
+fragment (no fast-math), matching §3.2.
+
+---
+
+## 9. Example corpus (build first, TDD)
+
+Per the [`03`](03-broader-subset.md) convention: author each as C, compile with
+`clang -O1 -S -emit-llvm -fno-discard-value-names`, stage under
+`examples/floating-point/` (the subdir `ExamplesSpec` ignores) while
+unsupported, then **promote to `examples/` top-level as each lands** so the parse
+gate and differential gate pick it up.
+
+Suggested sources (cover every §5 row):
+- `fadd.c` — `double f(double a,double b){return a+b;}` (arith + literals).
+- `fdiv.c` — `double g(double a,double b){return a/b;}` (the `/` vs `quot` split).
+- `fcmp.c` — `int p(double a,double b){return a<b;}` (fcmp → i1, mixed sorts via
+  the implicit `zext`).
+- `i2f.c` — `double h(int n){return n + 0.5;}` (sitofp + literal).
+- `f2i.c` — `int t(double x){return (int)x;}` (fptosi, round-toward-zero).
+- `fext.c` — `double w(float x){return x;}` (fpext); `ftr.c` —
+  `float n(double x){return x;}` (fptrunc).
+- A small **mixed loop** (φ-carried `double` accumulator) to exercise (T-Phi/Br)
+  with a floating parameter type — e.g. a fixed-iteration sum.
+
+---
+
+## 10. Tests (TDD — red first)
+
+- **`test/ExamplesSpec.hs`** — promoting examples extends the parse gate
+  automatically.
+- **New `test/TypeSystemSpec.hs`** — unit-test the type machinery in isolation
+  (it is the risky part): `elaborate` round-trips and errors off-subset; `rho`
+  table; `coerce` produces the exact §4 strings for each pair *and is `error`/`Left`
+  on undefined pairs; `validate` rejects a hand-built ill-typed function
+  (e.g. `fadd` on `i32` operands) — these are the executable form of §3's rules.
+- **New `test/FloatingSpec.hs`** — drive the real pipeline
+  (`runAlex … parseLLVMIR` → `translate` → `printProgram`) and assert the emitted
+  Haskell: `/` for `fdiv`, `+` for `fadd`, `truncate … :: Int32` for `fptosi`,
+  `float2Double` for `fpext`, `:: Double` annotations and round-tripping literals,
+  and the function signature `f :: Double -> Double -> Double`.
+  Run: `stack test --test-arguments '--match "/floating/"'`.
+- **`test/differential/run.py`** — every promoted FP example certified
+  bit-pattern-exact (§8).
+
+---
+
+## 11. Open decisions for the author
+
+1. **`frem` semantics.** Map to `Data.Fixed.mod'` and certify, or declare
+   out-of-subset? (C `fmod` vs `mod'` agreement needs a harness check.)
+2. **`ord`/`uno` (explicit NaN tests) only.** *Settled for the rest:* the
+   ordered **and** unordered relational predicates are both required — the corpus
+   forces it (`newton_sqrt.ll` emits `fcmp ugt`, §5), and on the no-NaN corpus
+   they collapse to the same Haskell comparison. The only still-open question is
+   whether to implement `ord`/`uno` (the bare `x == x` / `x /= x` NaN tests) or
+   error on them; nothing in the corpus emits them, so erroring until needed is
+   safe.
+3. **`uitofp`/`fptoui`** appear only for unsigned C source; the project's
+   signedness limitation (#02) already documents unsigned gaps. Include them in
+   `coerce` (cheap) but corpus-test only if a clean example exists.
+4. **Γ scope.** Build the full `Gamma` (recommended, enables clean condition
+   typing and #10) vs. stay fully local like #02? The plan assumes the former;
+   it is the small extra cost that buys the validation soundness and the Bool
+   seam.
+
+---
+
+## 12. Verification
+
+1. `stack build` — warning-clean (`-Wall` + the `-W…` set in `package.yaml`);
+   edit `package.yaml` (hpack) to register `TypeSystem`/new spec modules, never
+   the generated `.cabal`.
+2. `stack test` — `ExamplesSpec` parses all (incl. promoted FP examples);
+   `TypeSystemSpec`, `FloatingSpec` green; update golden `.hs` in
+   `docs/{gcd,prime,safe_div}` only if the `String`→`Ty` refactor changes their
+   (integer) output — it should not, which is itself a regression check that the
+   refactor preserved the integer path.
+3. `python3 test/differential/run.py` — every row certified, integer corpus
+   unchanged and new FP rows bit-pattern-exact.

--- a/examples/kahan_sum.ll
+++ b/examples/kahan_sum.ll
@@ -1,0 +1,41 @@
+define double @kahan_harmonic(i32 noundef %n) local_unnamed_addr #0 {
+entry:
+  %cmp.not9 = icmp slt i32 %n, 1
+  br i1 %cmp.not9, label %for.cond.cleanup, label %for.body
+
+for.cond.cleanup:                                 ; preds = %for.body, %entry
+  %sum.0.lcssa = phi double [ 0.000000e+00, %entry ], [ %add, %for.body ]
+  ret double %sum.0.lcssa
+
+for.body:                                         ; preds = %entry, %for.body
+  %sum.012 = phi double [ %add, %for.body ], [ 0.000000e+00, %entry ]
+  %c.011 = phi double [ %sub2, %for.body ], [ 0.000000e+00, %entry ]
+  %k.010 = phi i32 [ %inc, %for.body ], [ 1, %entry ]
+  %conv = uitofp nneg i32 %k.010 to double
+  %div = fdiv double 1.000000e+00, %conv
+  %sub = fsub double %div, %c.011
+  %add = fadd double %sum.012, %sub
+  %sub1 = fsub double %add, %sum.012
+  %sub2 = fsub double %sub1, %sub
+  %inc = add nuw i32 %k.010, 1
+  %exitcond.not = icmp eq i32 %k.010, %n
+  br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
+}
+
+; // Kahan (1965) compensated summation of the harmonic series
+; //   sum_{k=1}^{n} 1/k.
+; // The running compensation term c recovers low-order bits otherwise lost to
+; // rounding, so the result is far more accurate than a naive accumulator.
+; // Exercises an int->double conversion (the (double) k cast) inside a loop;
+; // since k is provably >= 1, clang emits uitofp (not sitofp).
+; extern "C" double kahan_harmonic(int n) {
+;     double sum = 0.0;
+;     double c   = 0.0;            // running compensation
+;     for (int k = 1; k <= n; k++) {
+;         double y = 1.0 / (double) k - c;
+;         double t = sum + y;
+;         c   = (t - sum) - y;     // recovers the part of y lost in (sum + y)
+;         sum = t;
+;     }
+;     return sum;
+; }

--- a/examples/logistic.ll
+++ b/examples/logistic.ll
@@ -1,0 +1,31 @@
+define double @logistic(double noundef %r, double noundef %x0, i32 noundef %iters) local_unnamed_addr #0 {
+entry:
+  %cmp5 = icmp sgt i32 %iters, 0
+  br i1 %cmp5, label %for.body, label %for.cond.cleanup
+
+for.cond.cleanup:                                 ; preds = %for.body, %entry
+  %x.0.lcssa = phi double [ %x0, %entry ], [ %mul1, %for.body ]
+  ret double %x.0.lcssa
+
+for.body:                                         ; preds = %entry, %for.body
+  %i.07 = phi i32 [ %inc, %for.body ], [ 0, %entry ]
+  %x.06 = phi double [ %mul1, %for.body ], [ %x0, %entry ]
+  %mul = fmul double %r, %x.06
+  %sub = fsub double 1.000000e+00, %x.06
+  %mul1 = fmul double %mul, %sub
+  %inc = add nuw nsw i32 %i.07, 1
+  %exitcond.not = icmp eq i32 %inc, %iters
+  br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
+}
+
+; // May (1976) logistic map  x_{n+1} = r * x_n * (1 - x_n).
+; // A pure floating-point recurrence exhibiting sensitive dependence on initial
+; // conditions (chaos for r ~ 3.57..4). Run for a runtime number of iterations
+; // so it stays a loop with a double-typed phi rather than unrolling.
+; extern "C" double logistic(double r, double x0, int iters) {
+;     double x = x0;
+;     for (int i = 0; i < iters; i++) {
+;         x = r * x * (1.0 - x);
+;     }
+;     return x;
+; }

--- a/examples/muller.ll
+++ b/examples/muller.ll
@@ -1,0 +1,37 @@
+define double @muller(i32 noundef %n) local_unnamed_addr #0 {
+entry:
+  %cmp6 = icmp sgt i32 %n, 0
+  br i1 %cmp6, label %for.body, label %for.cond.cleanup
+
+for.cond.cleanup:                                 ; preds = %for.body, %entry
+  %cur.0.lcssa = phi double [ 4.250000e+00, %entry ], [ %sub2, %for.body ]
+  ret double %cur.0.lcssa
+
+for.body:                                         ; preds = %entry, %for.body
+  %prev.09 = phi double [ %cur.07, %for.body ], [ 4.000000e+00, %entry ]
+  %i.08 = phi i32 [ %inc, %for.body ], [ 0, %entry ]
+  %cur.07 = phi double [ %sub2, %for.body ], [ 4.250000e+00, %entry ]
+  %div = fdiv double 1.500000e+03, %prev.09
+  %sub = fsub double 8.150000e+02, %div
+  %div1 = fdiv double %sub, %cur.07
+  %sub2 = fsub double 1.080000e+02, %div1
+  %inc = add nuw nsw i32 %i.08, 1
+  %exitcond.not = icmp eq i32 %inc, %n
+  br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
+}
+
+; // Muller's recurrence (J.-M. Muller, Elementary Functions):
+; //   E_{n+1} = 108 - (815 - 1500/E_{n-1}) / E_n,   E0 = 4, E1 = 4.25
+; // The exact limit is 5, but in floating point the iteration is drawn to the
+; // repulsive fixed point 100. A two-state (E_{n-1}, E_n) recurrence: exercises
+; // double-typed phi nodes carried around a loop.
+; extern "C" double muller(int n) {
+;     double prev = 4.0;     // E_{n-1}
+;     double cur  = 4.25;    // E_n
+;     for (int i = 0; i < n; i++) {
+;         double next = 108.0 - (815.0 - 1500.0 / prev) / cur;
+;         prev = cur;
+;         cur  = next;
+;     }
+;     return cur;
+; }

--- a/examples/newton_sqrt.ll
+++ b/examples/newton_sqrt.ll
@@ -1,0 +1,37 @@
+define double @newton_sqrt(double noundef %a, i32 noundef %iters) local_unnamed_addr #0 {
+entry:
+  %cmp = fcmp ugt double %a, 0.000000e+00
+  br i1 %cmp, label %for.cond.preheader, label %return
+
+for.cond.preheader:                               ; preds = %entry
+  %cmp17 = icmp sgt i32 %iters, 0
+  br i1 %cmp17, label %for.body, label %return
+
+for.body:                                         ; preds = %for.cond.preheader, %for.body
+  %i.09 = phi i32 [ %inc, %for.body ], [ 0, %for.cond.preheader ]
+  %x.08 = phi double [ %mul, %for.body ], [ %a, %for.cond.preheader ]
+  %div = fdiv double %a, %x.08
+  %add = fadd double %x.08, %div
+  %mul = fmul double %add, 5.000000e-01
+  %inc = add nuw nsw i32 %i.09, 1
+  %exitcond.not = icmp eq i32 %inc, %iters
+  br i1 %exitcond.not, label %return, label %for.body
+
+return:                                           ; preds = %for.body, %for.cond.preheader, %entry
+  %retval.0 = phi double [ 0.000000e+00, %entry ], [ %a, %for.cond.preheader ], [ %mul, %for.body ]
+  ret double %retval.0
+}
+
+; // Babylonian / Heron / Newton iteration for sqrt(a):
+; //   x_{n+1} = (x_n + a/x_n) / 2
+; // Implemented WITHOUT the llvm.sqrt intrinsic (so it stays inside the subset)
+; // and as a real loop over a runtime iteration count. A non-positive input is
+; // guarded, giving an early-return branch that exercises fcmp + control flow.
+; extern "C" double newton_sqrt(double a, int iters) {
+;     if (a <= 0.0) return 0.0;
+;     double x = a;                 // initial guess
+;     for (int i = 0; i < iters; i++) {
+;         x = 0.5 * (x + a / x);
+;     }
+;     return x;
+; }

--- a/examples/rump.ll
+++ b/examples/rump.ll
@@ -1,0 +1,40 @@
+define double @rump(double noundef %a, double noundef %b) local_unnamed_addr #0 {
+entry:
+  %mul = fmul double %b, %b
+  %mul1 = fmul double %mul, %mul
+  %mul2 = fmul double %mul, %mul1
+  %mul3 = fmul double %mul1, %mul1
+  %mul4 = fmul double %a, %a
+  %mul5 = fmul double %mul2, 3.337500e+02
+  %mul6 = fmul double %mul4, 1.100000e+01
+  %mul7 = fmul double %mul6, %mul
+  %sub = fsub double %mul7, %mul2
+  %mul8 = fmul double %mul1, 1.210000e+02
+  %sub9 = fsub double %sub, %mul8
+  %sub10 = fadd double %sub9, -2.000000e+00
+  %mul11 = fmul double %mul4, %sub10
+  %add = fadd double %mul5, %mul11
+  %mul12 = fmul double %mul3, 5.500000e+00
+  %add13 = fadd double %mul12, %add
+  %mul14 = fmul double %b, 2.000000e+00
+  %div = fdiv double %a, %mul14
+  %add15 = fadd double %div, %add13
+  ret double %add15
+}
+
+; // Rump (1988): a rational/polynomial expression whose naive floating-point
+; // evaluation is catastrophically wrong. At (a, b) = (77617, 33096) the exact
+; // value is approx -0.827396, but float/double arithmetic gives wildly wrong
+; // results (often the wrong sign and magnitude) due to cancellation.
+; // Pure scalar +, -, *, / — no intrinsics.
+; extern "C" double rump(double a, double b) {
+;     double b2 = b * b;
+;     double b4 = b2 * b2;
+;     double b6 = b4 * b2;
+;     double b8 = b4 * b4;
+;     double a2 = a * a;
+;     return 333.75 * b6
+;          + a2 * (11.0 * a2 * b2 - b6 - 121.0 * b4 - 2.0)
+;          + 5.5 * b8
+;          + a / (2.0 * b);
+; }

--- a/examples/sources/kahan_sum.cpp
+++ b/examples/sources/kahan_sum.cpp
@@ -1,0 +1,17 @@
+// Kahan (1965) compensated summation of the harmonic series
+//   sum_{k=1}^{n} 1/k.
+// The running compensation term c recovers low-order bits otherwise lost to
+// rounding, so the result is far more accurate than a naive accumulator.
+// Exercises an int->double conversion (the (double) k cast) inside a loop;
+// since k is provably >= 1, clang emits uitofp (not sitofp).
+extern "C" double kahan_harmonic(int n) {
+    double sum = 0.0;
+    double c   = 0.0;            // running compensation
+    for (int k = 1; k <= n; k++) {
+        double y = 1.0 / (double) k - c;
+        double t = sum + y;
+        c   = (t - sum) - y;     // recovers the part of y lost in (sum + y)
+        sum = t;
+    }
+    return sum;
+}

--- a/examples/sources/logistic.cpp
+++ b/examples/sources/logistic.cpp
@@ -1,0 +1,11 @@
+// May (1976) logistic map  x_{n+1} = r * x_n * (1 - x_n).
+// A pure floating-point recurrence exhibiting sensitive dependence on initial
+// conditions (chaos for r ~ 3.57..4). Run for a runtime number of iterations
+// so it stays a loop with a double-typed phi rather than unrolling.
+extern "C" double logistic(double r, double x0, int iters) {
+    double x = x0;
+    for (int i = 0; i < iters; i++) {
+        x = r * x * (1.0 - x);
+    }
+    return x;
+}

--- a/examples/sources/muller.cpp
+++ b/examples/sources/muller.cpp
@@ -1,0 +1,15 @@
+// Muller's recurrence (J.-M. Muller, Elementary Functions):
+//   E_{n+1} = 108 - (815 - 1500/E_{n-1}) / E_n,   E0 = 4, E1 = 4.25
+// The exact limit is 5, but in floating point the iteration is drawn to the
+// repulsive fixed point 100. A two-state (E_{n-1}, E_n) recurrence: exercises
+// double-typed phi nodes carried around a loop.
+extern "C" double muller(int n) {
+    double prev = 4.0;     // E_{n-1}
+    double cur  = 4.25;    // E_n
+    for (int i = 0; i < n; i++) {
+        double next = 108.0 - (815.0 - 1500.0 / prev) / cur;
+        prev = cur;
+        cur  = next;
+    }
+    return cur;
+}

--- a/examples/sources/newton_sqrt.cpp
+++ b/examples/sources/newton_sqrt.cpp
@@ -1,0 +1,13 @@
+// Babylonian / Heron / Newton iteration for sqrt(a):
+//   x_{n+1} = (x_n + a/x_n) / 2
+// Implemented WITHOUT the llvm.sqrt intrinsic (so it stays inside the subset)
+// and as a real loop over a runtime iteration count. A non-positive input is
+// guarded, giving an early-return branch that exercises fcmp + control flow.
+extern "C" double newton_sqrt(double a, int iters) {
+    if (a <= 0.0) return 0.0;
+    double x = a;                 // initial guess
+    for (int i = 0; i < iters; i++) {
+        x = 0.5 * (x + a / x);
+    }
+    return x;
+}

--- a/examples/sources/rump.cpp
+++ b/examples/sources/rump.cpp
@@ -1,0 +1,16 @@
+// Rump (1988): a rational/polynomial expression whose naive floating-point
+// evaluation is catastrophically wrong. At (a, b) = (77617, 33096) the exact
+// value is approx -0.827396, but float/double arithmetic gives wildly wrong
+// results (often the wrong sign and magnitude) due to cancellation.
+// Pure scalar +, -, *, / — no intrinsics.
+extern "C" double rump(double a, double b) {
+    double b2 = b * b;
+    double b4 = b2 * b2;
+    double b6 = b4 * b2;
+    double b8 = b4 * b4;
+    double a2 = a * a;
+    return 333.75 * b6
+         + a2 * (11.0 * a2 * b2 - b6 - 121.0 * b4 - 2.0)
+         + 5.5 * b8
+         + a / (2.0 * b);
+}

--- a/examples/sources/twosum.cpp
+++ b/examples/sources/twosum.cpp
@@ -1,0 +1,10 @@
+// Knuth / Moller TwoSum (an "error-free transformation"): for s = a + b it
+// recovers the exact rounding error err such that a + b == s + err in exact
+// arithmetic, using only floating additions/subtractions. Foundational
+// primitive of compensated-arithmetic algorithms (cf. Kahan summation).
+extern "C" double twosum_err(double a, double b) {
+    double s   = a + b;
+    double bb  = s - a;
+    double err = (a - (s - bb)) + (b - bb);
+    return err;
+}

--- a/examples/twosum.ll
+++ b/examples/twosum.ll
@@ -1,0 +1,21 @@
+define noundef double @twosum_err(double noundef %a, double noundef %b) local_unnamed_addr #0 {
+entry:
+  %add = fadd double %a, %b
+  %sub = fsub double %add, %a
+  %sub1 = fsub double %add, %sub
+  %sub2 = fsub double %a, %sub1
+  %sub3 = fsub double %b, %sub
+  %add4 = fadd double %sub3, %sub2
+  ret double %add4
+}
+
+; // Knuth / Moller TwoSum (an "error-free transformation"): for s = a + b it
+; // recovers the exact rounding error err such that a + b == s + err in exact
+; // arithmetic, using only floating additions/subtractions. Foundational
+; // primitive of compensated-arithmetic algorithms (cf. Kahan summation).
+; extern "C" double twosum_err(double a, double b) {
+;     double s   = a + b;
+;     double bb  = s - a;
+;     double err = (a - (s - bb)) + (b - bb);
+;     return err;
+; }

--- a/llvm-ir-to-functional.cabal
+++ b/llvm-ir-to-functional.cabal
@@ -36,6 +36,7 @@ library
       PrintAnf
       Translate
       TranslateAux
+      TypeSystem
   other-modules:
       Paths_llvm_ir_to_functional
   autogen-modules:
@@ -81,6 +82,7 @@ test-suite llvm-ir-to-functional-test
   other-modules:
       BitWidthSpec
       ExamplesSpec
+      FloatingSpec
       LexerSpec
       ParserSpec
       Spec

--- a/llvm-ir-to-functional.cabal
+++ b/llvm-ir-to-functional.cabal
@@ -84,6 +84,7 @@ test-suite llvm-ir-to-functional-test
       ExamplesSpec
       FloatingSpec
       LexerSpec
+      NameNormalizerSpec
       ParserSpec
       Spec
       TranslateSpec

--- a/src/Anf.hs
+++ b/src/Anf.hs
@@ -65,8 +65,11 @@ data Select
   = Select Value Value Value
   deriving (Show, Eq)
 
+-- | A comparison: the predicate, the /operand/ 'Ty' (so the printer can pick
+-- NaN-faithful codegen for floating @fcmp@ vs a plain operator for integer
+-- @icmp@), and the two operands. The result is always an i1.
 data Icmp
-  = Icmp String Value Value
+  = Icmp String Ty Value Value
   deriving (Show, Eq)
 
 data Flow

--- a/src/Anf.hs
+++ b/src/Anf.hs
@@ -16,13 +16,15 @@ module Anf (
   Value(..),
 ) where
 
+import TypeSystem (Ty)
+
 newtype Program = Program [Function] deriving (Show, Eq)
 
--- | A whole LLVM function. The @[String]@ are the Haskell types of the
--- arguments and the trailing 'String' is the return type; together they form
--- the emitted top-level signature, which anchors bit-width inference.
+-- | A whole LLVM function. The @['Ty']@ are the argument types and the trailing
+-- 'Ty' is the return type; together they form the emitted top-level signature,
+-- which anchors bit-width inference.
 data Function =
-  Function String [ArgumentDef] [String] String Lambda Call
+  Function String [ArgumentDef] [Ty] Ty Lambda Call
   deriving (Show, Eq)
 
 newtype ArgumentDef =
@@ -38,24 +40,25 @@ newtype Expr
   -- | ExpCall Call
   deriving (Show, Eq)
 
--- | Each binding carries the Haskell type of its result (e.g. @"Int32"@) so the
--- printer can annotate it and pin the width. 'DeclConvOp' is the exception: the
--- conversion already names its target type, so it needs no separate annotation.
+-- | Each binding carries the 'Ty' of its result so the printer can annotate it
+-- and pin the representation. 'DeclConvOp' is the exception: the conversion
+-- already names its target type, so it needs no separate annotation.
 data Decl
-  = DeclBinOp String String BinOp
-  | DeclCall String String Call
-  | DeclIcmp String String Icmp
-  | DeclSelect String String Select
+  = DeclBinOp String Ty BinOp
+  | DeclCall String Ty Call
+  | DeclIcmp String Ty Icmp
+  | DeclSelect String Ty Select
   | DeclConvOp String ConvOp
   -- | An LLVM @freeze@: a typed alias binding @name = value@ (freeze is the
-  -- identity in the pure subset). The 'String' is the result type annotation.
-  | DeclFreeze String String Value
+  -- identity in the pure subset). The 'Ty' is the result type annotation.
+  | DeclFreeze String Ty Value
   deriving (Show, Eq)
 
--- | A width conversion: the LLVM op name (@trunc@\/@zext@\/@sext@), the source
--- and target bit-widths, and the value being converted.
+-- | A conversion: the LLVM op name (@trunc@\/@zext@\/@sext@\/@sitofp@\/…), the
+-- source and target 'Ty' (conversions may cross sorts, so widths alone are
+-- insufficient), and the value being converted.
 data ConvOp
-  = ConvOp String Int Int Value
+  = ConvOp String Ty Ty Value
   deriving (Show, Eq)
 
 data Select
@@ -85,6 +88,9 @@ data IfThenElse
 
 data Value
   = Const Integer
+  -- | A floating constant: the (Haskell-renderable) literal text and its 'Ty'
+  -- (so the printer emits @Float@ vs @Double@ and an explicitly-typed literal).
+  | FConst String Ty
   | Name String
   | Unit
   deriving (Show, Eq)

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -4,6 +4,7 @@ module Ast (
   Program(..),
   Name(..),
   IntegerValue(..),
+  FloatValue(..),
   Value(..),
   Type(..),
   Call(..),
@@ -111,8 +112,15 @@ data IntegerValue a
   = IntegerValue a Integer
   deriving (Foldable, Show, Eq)
 
+-- | A floating-point literal, carried as its raw (decimal-exponent) LLVM
+-- spelling, which is also a valid Haskell literal.
+data FloatValue a
+  = FloatValue a String
+  deriving (Foldable, Show, Eq)
+
 data Value a
   = ValueInt (IntegerValue a)
+  | ValueFloat (FloatValue a)
   | ValueName (Name a)
   deriving (Foldable, Show, Eq)
 

--- a/src/Lexer.x
+++ b/src/Lexer.x
@@ -70,7 +70,10 @@ tokens :-
 <0> fsub          { createToken BinOp }
 <0> fmul          { createToken BinOp }
 <0> fdiv          { createToken BinOp }
-<0> frem          { createToken BinOp }
+-- frem is intentionally NOT supported: it has C fmod semantics (quotient
+-- truncated toward zero, result takes the dividend's sign), which no pure
+-- Haskell primitive matches bit-exactly (Data.Fixed.mod' is floor-based). See
+-- plans/09-floating-point.md §11.1.
 
 -- Conversion operations
 <0> trunc         { createToken ConvOp }

--- a/src/Lexer.x
+++ b/src/Lexer.x
@@ -99,11 +99,11 @@ tokens :-
 <0> to          { tok To }
 
 -- Beginning of a block. Clang emits named labels containing '.'
--- (e.g. @for.cond.cleanup:@); normalizeName (removePunc) strips the '.' so the
--- def and its @%for.cond.cleanup@ reference collapse to the same identifier.
--- '$' is deliberately not accepted: clang does not emit it in labels and
--- removePunc does not strip it, so it could not be made a valid identifier.
-<0> ([a-zA-Z_0-9\.])+ ":" { createToken BasicBlock }
+-- (e.g. @for.cond.cleanup:@), and LLVM also admits '$'; normalizeName
+-- (removePunc) strips both, so a label and its @%for.cond.cleanup@ reference
+-- collapse to the same valid Haskell identifier (matching @local_id@/@global_id@,
+-- which accept the same characters).
+<0> ([a-zA-Z_0-9\.\$])+ ":" { createToken BasicBlock }
 
 -- Identifiers
 <0> @global_id     { createToken GIdentifier }

--- a/src/Lexer.x
+++ b/src/Lexer.x
@@ -37,6 +37,7 @@ tokens :-
 <0> define        { tok Define }
 <0> declare       { tok Declare }
 <0> icmp          { tok Icmp }
+<0> fcmp          { tok Fcmp }
 <0> ret           { tok Return }
 <0> br            { tok Br }
 <0> phi           { tok Phi }
@@ -64,11 +65,24 @@ tokens :-
 <0> lshr          { createToken BinOp }
 <0> ashr          { createToken BinOp }
 <0> xor           { createToken BinOp }
+-- Floating-point arithmetic
+<0> fadd          { createToken BinOp }
+<0> fsub          { createToken BinOp }
+<0> fmul          { createToken BinOp }
+<0> fdiv          { createToken BinOp }
+<0> frem          { createToken BinOp }
 
 -- Conversion operations
 <0> trunc         { createToken ConvOp }
 <0> zext          { createToken ConvOp }
 <0> sext          { createToken ConvOp }
+-- Floating-point conversions
+<0> sitofp        { createToken ConvOp }
+<0> uitofp        { createToken ConvOp }
+<0> fptosi        { createToken ConvOp }
+<0> fptoui        { createToken ConvOp }
+<0> fpext         { createToken ConvOp }
+<0> fptrunc       { createToken ConvOp }
 
 -- Markers
 <0> "="         { tok Assign }
@@ -81,8 +95,10 @@ tokens :-
 <0> ","         { tok Comma }
 <0> to          { tok To }
 
--- Beginning of a block
-<0> ([a-zA-Z_0-9])+ ":" { createToken BasicBlock }
+-- Beginning of a block. Clang emits named labels containing '.' and '$'
+-- (e.g. @for.cond.cleanup:@); normalizeName strips the punctuation so the def
+-- and its @%for.cond.cleanup@ references collapse to the same identifier.
+<0> ([a-zA-Z_0-9\.\$])+ ":" { createToken BasicBlock }
 
 -- Identifiers
 <0> @global_id     { createToken GIdentifier }
@@ -92,13 +108,17 @@ tokens :-
 <0> (void | label | i$digit+ | half | float | double | fp128 | ptr) { createToken Type }
 
 -- Constants
+-- Floating-point literal (decimal-exponent form, e.g. 4.250000e+00). Must come
+-- before the integer rule; maximal munch picks it because it is longer.
+<0> \-?$digit+\.$digit+([eE][\+\-]?$digit+)? { createToken FloatLit }
 <0> \-?$digit+   { tokInteger }
 <0> \"[^\"]*\"   { createToken String }
 <0> false | true { tokInteger }
 
 -- Types of comparison
-
-<0> (eq | ne | ugt | uge | ult | ule | sgt | sge | slt | sle) { createToken Cmp }
+-- Integer (icmp) predicates plus floating (fcmp) ordered/unordered ones. The
+-- u{gt,ge,lt,le} spellings are shared; ord/uno (NaN tests) are out of subset.
+<0> (eq | ne | ugt | uge | ult | ule | sgt | sge | slt | sle | oeq | one | ogt | oge | olt | ole | ueq | une) { createToken Cmp }
 
 -- Ignore for now
 <0> "#"$digit+         ;
@@ -110,6 +130,17 @@ tokens :-
 <0> inbounds           ;
 <0> nsw                ;
 <0> nuw                ;
+-- Non-negativity hint on zext/uitofp, and fast-math flags: non-semantic, so
+-- dropped exactly like nsw/nuw (see plans/09-floating-point.md).
+<0> nneg               ;
+<0> fast               ;
+<0> nnan               ;
+<0> ninf               ;
+<0> nsz                ;
+<0> arcp               ;
+<0> contract           ;
+<0> reassoc            ;
+<0> afn                ;
 <0> tail               ;
 <0> dso_local          ;
 <0> noundef            ;
@@ -150,6 +181,7 @@ data Token
   -- Constants
   | String ByteString
   | Integer Integer
+  | FloatLit ByteString
   -- Type
   | Type ByteString
   -- Keywords
@@ -161,6 +193,7 @@ data Token
   | Call
   | Br
   | Icmp
+  | Fcmp
   | Store
   | Load
   | GetElementPtr

--- a/src/Lexer.x
+++ b/src/Lexer.x
@@ -98,10 +98,12 @@ tokens :-
 <0> ","         { tok Comma }
 <0> to          { tok To }
 
--- Beginning of a block. Clang emits named labels containing '.' and '$'
--- (e.g. @for.cond.cleanup:@); normalizeName strips the punctuation so the def
--- and its @%for.cond.cleanup@ references collapse to the same identifier.
-<0> ([a-zA-Z_0-9\.\$])+ ":" { createToken BasicBlock }
+-- Beginning of a block. Clang emits named labels containing '.'
+-- (e.g. @for.cond.cleanup:@); normalizeName (removePunc) strips the '.' so the
+-- def and its @%for.cond.cleanup@ reference collapse to the same identifier.
+-- '$' is deliberately not accepted: clang does not emit it in labels and
+-- removePunc does not strip it, so it could not be made a valid identifier.
+<0> ([a-zA-Z_0-9\.])+ ":" { createToken BasicBlock }
 
 -- Identifiers
 <0> @global_id     { createToken GIdentifier }

--- a/src/NameNormalizer.hs
+++ b/src/NameNormalizer.hs
@@ -36,11 +36,15 @@ normalizeGlobal name =
 normalizeBlockName :: ByteString -> String
 normalizeBlockName name = "f" ++ removePunc (unpack name)
 
+-- | Strip the punctuation the lexer admits inside LLVM identifiers, leaving a
+-- valid Haskell identifier body. Covers every such character: the sigils
+-- (@%@\/@\@@), the dotted/dollar name chars LLVM allows in locals, globals and
+-- block labels (@.@\/@$@ — e.g. @%for.cond@, @\@foo$bar@), and the label colon.
 removePunc :: String -> String
 removePunc = filter (`notElem` punctuation)
   where
     punctuation :: [Char]
-    punctuation = ",.?!-:;\"'%@"
+    punctuation = ",.?!-:;\"'%@$"
 
 unpack :: LBS.ByteString -> String
 unpack = LBS.unpack

--- a/src/NameNormalizer.hs
+++ b/src/NameNormalizer.hs
@@ -1,5 +1,5 @@
 
-module NameNormalizer (normalizeName, normalizeBlockName, normalizeOp, normalizeGlobal) where
+module NameNormalizer (normalizeName, normalizeBlockName, normalizeOp, normalizeGlobal, normalizeFloat) where
 
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.ByteString.Lazy.Char8 (ByteString)
@@ -9,6 +9,12 @@ normalizeName name = "a" ++ removePunc (unpack name)
 
 normalizeOp :: ByteString -> String
 normalizeOp name = removePunc (unpack name)
+
+-- | A floating-point literal's LLVM spelling is already a valid Haskell literal
+-- (decimal-exponent form), so it passes through verbatim. The printer wraps it
+-- in parentheses and annotates it with its type.
+normalizeFloat :: ByteString -> String
+normalizeFloat = unpack
 
 -- | Normalize a global (function) name to a valid, non-colliding Haskell
 -- identifier. Like 'normalizeOp' it strips punctuation, but it also escapes

--- a/src/Parser.y
+++ b/src/Parser.y
@@ -27,6 +27,7 @@ import NameNormalizer
 -- Constants
   string     { L.RangedToken (L.String _) _ }
   integer    { L.RangedToken (L.Integer _) _ }
+  floatlit   { L.RangedToken (L.FloatLit _) _ }
 -- Type
   type       { L.RangedToken (L.Type _) _ }
   i1         { L.RangedToken (L.Type _) _ }
@@ -39,6 +40,7 @@ import NameNormalizer
   call       { L.RangedToken L.Call _ }
   br         { L.RangedToken L.Br _ }
   icmp       { L.RangedToken L.Icmp _ }
+  fcmp       { L.RangedToken L.Fcmp _ }
   store      { L.RangedToken L.Store _ }
   load       { L.RangedToken L.Load _ }
   getelementptr { L.RangedToken L.GetElementPtr _ }
@@ -147,9 +149,13 @@ gname :: { Name L.Range }
 integerValue :: { IntegerValue L.Range }
   : integer                          { unTok $1 (\range (L.Integer value) -> IntegerValue range value) }
 
+floatValue :: { FloatValue L.Range }
+  : floatlit                         { unTok $1 (\range (L.FloatLit s) -> FloatValue range (normalizeFloat s)) }
+
 value :: { Value L.Range }
   : lname        { ValueName $1 }
   | integerValue { ValueInt $1 }
+  | floatValue   { ValueFloat $1 }
 
 typeAnotation :: { Type L.Range }
   : type                             { unTok $1 (\range (L.Type typeName) -> Type range (normalizeOp typeName)) }
@@ -189,8 +195,12 @@ ret :: { Return L.Range }
   : return typeAnotation value       { Return (L.rtRange $1 <-> info $3) $2 (Just $3) }
   | return typeAnotation             { Return (L.rtRange $1 <-> info $2) $2 Nothing }
 
+-- icmp and fcmp share a shape and (for this subset) the same translation: both
+-- yield an i1 and print as @if a <cmp> b then 1 else 0@. The predicate token
+-- already carries the (ordered/unordered, signed/unsigned) distinction.
 icmpCall :: { Icmp L.Range }
   : icmp cmpDef typeAnotation value ',' value { Icmp (L.rtRange $1 <-> info $6) $2 $3 $4 $6 }
+  | fcmp cmpDef typeAnotation value ',' value { Icmp (L.rtRange $1 <-> info $6) $2 $3 $4 $6 }
 
 cmpDef :: { Cmp L.Range }
   : cmp                              { unTok $1 (\range (L.Cmp cmp) -> Cmp range (normalizeOp cmp)) }

--- a/src/PrintAnf.hs
+++ b/src/PrintAnf.hs
@@ -6,7 +6,7 @@ import Data.List (intercalate)
 
 import Anf
 import TranslateAux
-import TypeSystem (Ty, rho, widthOf)
+import TypeSystem (Ty, rho, widthOf, isFloating)
 
 import Text.Printf (printf)
 
@@ -14,7 +14,6 @@ header :: String
 header = "import Data.Bits\n\
          \import Data.Int\n\
          \import Data.Word\n\
-         \import Data.Fixed (mod')\n\
          \import GHC.Float (float2Double, double2Float)\n\n"
 
 printProgram :: Program -> String
@@ -66,7 +65,34 @@ annot :: String -> Ty -> String
 annot expr ty = printf "(%s) :: %s" expr (rho ty)
 
 printIcmp :: Icmp -> String
-printIcmp (Icmp cmp a b) = printf "if %s %s %s then 1 else 0" (printValue a) (translateCmpType cmp) (printValue b)
+printIcmp (Icmp cmp ty a b) =
+  printf "if %s then 1 else 0" (cmpExpr ty cmp (printValue a) (printValue b))
+
+-- | The Haskell boolean expression for a comparison predicate.
+--
+-- Integer @icmp@ predicates and floating @fcmp@ /ordered/ predicates map to a
+-- plain operator: Haskell's @<@\/@>@\/@==@ already yield 'False' on NaN, which
+-- is exactly LLVM's ordered semantics. The float /unordered/ predicates
+-- (@u{gt,ge,lt,le}@, @ueq@), which are 'True' whenever an operand is NaN, and
+-- the ordered @one@ (which requires both operands non-NaN) need explicit
+-- 'isNaN' guards to stay faithful. (@une@ already matches Haskell @/=@: both
+-- are 'True' on NaN.)
+cmpExpr :: Ty -> String -> String -> String -> String
+cmpExpr ty cmp a b
+  | isFloating ty = case cmp of
+      "ugt" -> unordered ">"
+      "uge" -> unordered ">="
+      "ult" -> unordered "<"
+      "ule" -> unordered "<="
+      "ueq" -> unordered "=="
+      "one" -> printf "%s == %s && %s == %s && %s /= %s" a a b b a b
+      _     -> plain
+  | otherwise = plain
+  where
+    plain = printf "%s %s %s" a (translateCmpType cmp) b
+    -- unordered: true if either operand is NaN, or the ordered relation holds.
+    unordered :: String -> String
+    unordered op = printf "isNaN %s || isNaN %s || %s %s %s" a b a op b
 
 printSelect :: Select -> String
 printSelect (Select a b c) = printf "if %s /= 0 then %s else %s" (printValue a) (printValue b) (printValue c)

--- a/src/PrintAnf.hs
+++ b/src/PrintAnf.hs
@@ -6,11 +6,16 @@ import Data.List (intercalate)
 
 import Anf
 import TranslateAux
+import TypeSystem (Ty, rho, widthOf)
 
 import Text.Printf (printf)
 
 header :: String
-header = "import Data.Bits\nimport Data.Int\nimport Data.Word\n\n"
+header = "import Data.Bits\n\
+         \import Data.Int\n\
+         \import Data.Word\n\
+         \import Data.Fixed (mod')\n\
+         \import GHC.Float (float2Double, double2Float)\n\n"
 
 printProgram :: Program -> String
 printProgram (Program functions) = header ++ intercalate "\n\n" (map printFunction functions)
@@ -20,7 +25,7 @@ printFunction (Function name args argTypes retType lambda call) =
   let
     functionArgs = unrollArguments args
     firstBlockLabel = printCall call
-    signature = signatureString name (intercalate " -> " (argTypes ++ [retType]))
+    signature = signatureString name (intercalate " -> " (map rho (argTypes ++ [retType])))
   in signature ++ functionString name functionArgs (printLet lambda 2) firstBlockLabel
 
 unrollArguments :: [ArgumentDef] -> String
@@ -43,6 +48,7 @@ printExpr (ExpDecl decl) l = indent l $ printDecl decl
 printCall :: Call -> String
 printCall (Call (Name fname) values) = fname ++ " " ++ unwords (map printValue values)
 printCall (Call (Const value) _) = show value
+printCall (Call c@(FConst _ _) _) = printValue c
 printCall (Call Unit _) = "()"
 
 printDecl :: Decl -> String
@@ -56,8 +62,8 @@ printDecl (DeclConvOp name convop) = declString name (printConvOp convop)
 printDecl (DeclFreeze name ty value) = declString name (annot (printValue value) ty)
 
 -- | Pin a binding's result type: @(expr) :: Int32@.
-annot :: String -> String -> String
-annot = printf "(%s) :: %s"
+annot :: String -> Ty -> String
+annot expr ty = printf "(%s) :: %s" expr (rho ty)
 
 printIcmp :: Icmp -> String
 printIcmp (Icmp cmp a b) = printf "if %s %s %s then 1 else 0" (printValue a) (translateCmpType cmp) (printValue b)
@@ -67,13 +73,23 @@ printSelect (Select a b c) = printf "if %s /= 0 then %s else %s" (printValue a) 
 
 printConvOp :: ConvOp -> String
 printConvOp (ConvOp op src tgt value) = case op of
-  -- zext zero-extends: round-trip through the unsigned word type first.
-  "zext" -> printf "fromIntegral (fromIntegral %s :: %s) :: %s" v (widthToWordType src) tgtTy
-  -- trunc (narrow) and sext (signed widen) are both a plain signed conversion.
-  _      -> printf "fromIntegral %s :: %s" v tgtTy
+  -- zext / uitofp zero-extend the source: round-trip through its unsigned word
+  -- type first, so the sign bit is not propagated.
+  "zext"    -> printf "fromIntegral (fromIntegral %s :: %s) :: %s" v (wordOf src) tgtTy
+  "uitofp"  -> printf "fromIntegral (fromIntegral %s :: %s) :: %s" v (wordOf src) tgtTy
+  -- float -> int is truncation toward zero (LLVM semantics), i.e. `truncate`.
+  "fptosi"  -> printf "truncate %s :: %s" v tgtTy
+  "fptoui"  -> printf "fromIntegral (truncate %s :: %s) :: %s" v (wordOf tgt) tgtTy
+  -- float <-> double use the bit-exact GHC.Float primitives.
+  "fpext"   -> printf "float2Double %s" v
+  "fptrunc" -> printf "double2Float %s" v
+  -- trunc (narrow), sext (signed widen) and sitofp are all a plain signed
+  -- `fromIntegral` into the target type.
+  _         -> printf "fromIntegral %s :: %s" v tgtTy
   where
     v = printValue value
-    tgtTy = widthToHsType tgt
+    tgtTy = rho tgt
+    wordOf = widthToWordType . widthOf
 
 printBinOp :: BinOp -> String
 printBinOp (BinOp op left right) = printValue left ++ translateOperator op ++ rhs
@@ -85,6 +101,9 @@ printBinOp (BinOp op left right) = printValue left ++ translateOperator op ++ rh
 
 printValue :: Value -> String
 printValue (Const c) = if c < 0 then "(" ++ show c ++ ")" else show c
+-- A floating literal is always parenthesised and explicitly typed, so it is
+-- unambiguous as an operand/argument and pins Float vs Double (no defaulting).
+printValue (FConst txt ty) = printf "(%s :: %s)" txt (rho ty)
 printValue (Name n) = n
 printValue Unit = "()"
 

--- a/src/Translate.hs
+++ b/src/Translate.hs
@@ -157,7 +157,7 @@ anfSelect ty (Ast.Select _ _ condValue value1 value2) =
 
 anfIcmp :: Ast.Icmp Range -> Anf.Icmp
 anfIcmp (Ast.Icmp _ (Ast.Cmp _ cmp) ty value1 value2) =
-  Anf.Icmp cmp (anfValue (typeStr ty) value1) (anfValue (typeStr ty) value2)
+  Anf.Icmp cmp (typeStr ty) (anfValue (typeStr ty) value1) (anfValue (typeStr ty) value2)
 
 anfCall :: Ast.Call Range -> Anf.Call
 anfCall (Ast.Call _ _ name args) =

--- a/src/Translate.hs
+++ b/src/Translate.hs
@@ -12,6 +12,7 @@ import Data.List (isPrefixOf)
 import Data.Maybe (fromJust)
 
 import TranslateAux
+import TypeSystem (Ty(..), elaborate)
 import AstHelpers
 
 import Dominance (buildGraph, dominance)
@@ -34,14 +35,14 @@ buildAnfFromFunction (Ast.FunctionDef _ retTy name args blocks) dom =
     callFirstBlock = Anf.Call (Anf.Name firstBlockLabel) []
 -- buildAnfFromFunction _ _ = undefined
 
--- | The Haskell type of an LLVM type annotation.
-typeStr :: Ast.Type Range -> String
-typeStr (Ast.Type _ t) = hsTypeOfLlvm t
+-- | Elaborate an LLVM type annotation into the internal 'Ty'.
+typeStr :: Ast.Type Range -> Ty
+typeStr (Ast.Type _ t) = elaborate t
 
--- | Argument type spellings for the function signature. A nullary LLVM function
--- takes a single @()@ (mirroring 'anfArgs').
-argTypes :: [Ast.ArgumentDef Range] -> [String]
-argTypes [] = ["()"]
+-- | Argument types for the function signature. A nullary LLVM function takes a
+-- single @()@ (mirroring 'anfArgs').
+argTypes :: [Ast.ArgumentDef Range] -> [Ty]
+argTypes [] = [TyUnit]
 argTypes as = map (\(Ast.ArgumentDef _ t _) -> typeStr t) as
 
 firstBlockName :: [Ast.BasicBlock Range] -> String
@@ -114,17 +115,18 @@ callArgsFromBlockPhis (Ast.BasicBlock _ _ [] _ _) _ = [Anf.Unit]
 callArgsFromBlockPhis (Ast.BasicBlock _ _ phis _ _) label = map (callArgFromPhi label) phis
 
 callArgFromPhi :: String -> Ast.PhiDec Range -> Anf.Value
-callArgFromPhi currentLabel (Ast.PhiDec _ _ (Ast.Phi _ _ values)) = getValueForCurrentLabel values currentLabel
+callArgFromPhi currentLabel (Ast.PhiDec _ _ (Ast.Phi _ ty values)) = getValueForCurrentLabel (typeStr ty) values currentLabel
 
-getValueForCurrentLabel :: [(Ast.Value Range, Ast.Name Range)] -> String -> Anf.Value
-getValueForCurrentLabel values currentLabel =
+-- | Resolve a φ-incoming value for the source block, typed by the φ-node's
+-- declared type (so a floating literal is tagged 'Anf.FConst' correctly).
+getValueForCurrentLabel :: Ty -> [(Ast.Value Range, Ast.Name Range)] -> String -> Anf.Value
+getValueForCurrentLabel ty values currentLabel =
   case filter (\(_, name) -> nameToString name == currentLabel) values of
-    [(Ast.ValueInt (Ast.IntegerValue _ value), _)] -> Anf.Const value
-    [(Ast.ValueName name, _)] -> Anf.Name (nameToString name)
+    [(value, _)] -> anfValue ty value
     _ -> error $ "Phi value not found for label " ++ currentLabel
 
 anfReturn :: Ast.Return Range -> Anf.Call
-anfReturn (Ast.Return _ _ (Just valueReturned)) = Anf.Call (anfValue valueReturned) []
+anfReturn (Ast.Return _ ty (Just valueReturned)) = Anf.Call (anfValue (typeStr ty) valueReturned) []
 anfReturn (Ast.Return _ _ Nothing) = Anf.Call Anf.Unit []
 
 anfBindings :: [Ast.Stmt Range] -> [Anf.Expr]
@@ -138,20 +140,24 @@ anfDec :: Ast.Dec Range -> Anf.Decl
 anfDec (Ast.DecCall _ name call@(Ast.Call _ ty _ _)) = Anf.DeclCall (nameToString name) (typeStr ty) (anfCall call)
 anfDec (Ast.DecBinOp _ name binop@(Ast.BinOpCall _ _ ty _ _)) = Anf.DeclBinOp (nameToString name) (typeStr ty) (anfBinOp binop)
 anfDec (Ast.DecConvOp _ name convop) = Anf.DeclConvOp (nameToString name) (anfConvOp convop)
--- icmp always yields an i1, regardless of its (operand) type annotation.
-anfDec (Ast.DecIcmp _ name icmp) = Anf.DeclIcmp (nameToString name) (widthToHsType 1) (anfIcmp icmp)
-anfDec (Ast.DecSelect _ name select@(Ast.Select _ ty _ _ _)) = Anf.DeclSelect (nameToString name) (typeStr ty) (anfSelect select)
-anfDec (Ast.DecFreeze _ name (Ast.Freeze _ ty value)) = Anf.DeclFreeze (nameToString name) (typeStr ty) (anfValue value)
+-- icmp/fcmp always yield an i1, regardless of their (operand) type annotation.
+anfDec (Ast.DecIcmp _ name icmp) = Anf.DeclIcmp (nameToString name) (TyInt 1) (anfIcmp icmp)
+anfDec (Ast.DecSelect _ name select@(Ast.Select _ ty _ _ _)) = Anf.DeclSelect (nameToString name) (typeStr ty) (anfSelect (typeStr ty) select)
+anfDec (Ast.DecFreeze _ name (Ast.Freeze _ ty value)) = Anf.DeclFreeze (nameToString name) (typeStr ty) (anfValue (typeStr ty) value)
 
 anfConvOp :: Ast.ConvOpCall Range -> Anf.ConvOp
-anfConvOp (Ast.ConvOpCall _ (Ast.ConvOp _ op) (Ast.Type _ srcT) value (Ast.Type _ tgtT)) =
-  Anf.ConvOp op (llvmIntWidth srcT) (llvmIntWidth tgtT) (anfValue value)
+anfConvOp (Ast.ConvOpCall _ (Ast.ConvOp _ op) srcT value tgtT) =
+  Anf.ConvOp op (typeStr srcT) (typeStr tgtT) (anfValue (typeStr srcT) value)
 
-anfSelect :: Ast.Select Range -> Anf.Select
-anfSelect (Ast.Select _ _ condValue value1 value2) = Anf.Select (anfValue condValue) (anfValue value1) (anfValue value2)
+-- | The select condition is an i1 (typed 'TyInt 1'); both arms carry the
+-- result type @ty@.
+anfSelect :: Ty -> Ast.Select Range -> Anf.Select
+anfSelect ty (Ast.Select _ _ condValue value1 value2) =
+  Anf.Select (anfValue (TyInt 1) condValue) (anfValue ty value1) (anfValue ty value2)
 
 anfIcmp :: Ast.Icmp Range -> Anf.Icmp
-anfIcmp (Ast.Icmp _ (Ast.Cmp _ cmp) _ value1 value2) = Anf.Icmp cmp (anfValue value1) (anfValue value2)
+anfIcmp (Ast.Icmp _ (Ast.Cmp _ cmp) ty value1 value2) =
+  Anf.Icmp cmp (anfValue (typeStr ty) value1) (anfValue (typeStr ty) value2)
 
 anfCall :: Ast.Call Range -> Anf.Call
 anfCall (Ast.Call _ _ name args) =
@@ -176,17 +182,23 @@ intrinsicRewrite callee args
   | otherwise                      = Nothing
 
 anfBinOp :: Ast.BinOpCall Range -> Anf.BinOp
-anfBinOp (Ast.BinOpCall _ (Ast.BinOp _ binop) _ value1 value2) = Anf.BinOp binop (anfValue value1) (anfValue value2)
+anfBinOp (Ast.BinOpCall _ (Ast.BinOp _ binop) ty value1 value2) =
+  Anf.BinOp binop (anfValue (typeStr ty) value1) (anfValue (typeStr ty) value2)
 
 anfCallArgs :: [Ast.CallArgument Range] -> [Anf.Value]
 anfCallArgs = map anfCallArg
 
 anfCallArg :: Ast.CallArgument Range -> Anf.Value
-anfCallArg (Ast.CallArgument _ _ value) = anfValue value
+anfCallArg (Ast.CallArgument _ ty value) = anfValue (typeStr ty) value
 
-anfValue :: Ast.Value Range -> Anf.Value
-anfValue (Ast.ValueInt (Ast.IntegerValue _ int)) = Anf.Const int
-anfValue (Ast.ValueName name) = Anf.Name (nameToString name)
+-- | Translate an operand. The contextual 'Ty' (from the enclosing instruction's
+-- annotation) is only consulted for floating literals, which must be tagged so
+-- the printer emits @Float@\/@Double@ and an explicitly-typed literal; names and
+-- integer literals print the same regardless.
+anfValue :: Ty -> Ast.Value Range -> Anf.Value
+anfValue _ (Ast.ValueInt (Ast.IntegerValue _ int)) = Anf.Const int
+anfValue _ (Ast.ValueName name) = Anf.Name (nameToString name)
+anfValue ty (Ast.ValueFloat (Ast.FloatValue _ txt)) = Anf.FConst txt ty
 
 valueFromName :: Ast.Name Range -> Anf.Value
 valueFromName = Anf.Name . nameToString

--- a/src/TranslateAux.hs
+++ b/src/TranslateAux.hs
@@ -71,12 +71,12 @@ translateOperator str = case str of
   -- documented signedness limitation (see plans/03-broader-subset.md).
   "ashr" -> " `shiftR` "
   -- floating-point arithmetic. fadd/fsub/fmul share Haskell's Num operators
-  -- with their integer counterparts; fdiv is true division and frem is C fmod.
+  -- with their integer counterparts; fdiv is true division. (frem is out of
+  -- subset: C fmod has no bit-exact pure-Haskell lowering -- see Lexer.x.)
   "fadd" -> " + "
   "fsub" -> " - "
   "fmul" -> " * "
   "fdiv" -> " / "
-  "frem" -> " `mod'` "
   _ -> "UNKNOWN OP"
 
 unpack :: LBS.ByteString -> String

--- a/src/TranslateAux.hs
+++ b/src/TranslateAux.hs
@@ -8,7 +8,6 @@ module TranslateAux (
   indent,
   indentEach,
   llvmIntWidth,
-  hsTypeOfLlvm,
   widthToHsType,
   widthToWordType
   ) where
@@ -24,6 +23,12 @@ nameToString :: Ast.Name Range -> String
 nameToString (Ast.GName _ name) = name
 nameToString (Ast.LName _ name) = name
 
+-- | Spelling of a comparison predicate. Covers both integer @icmp@ predicates
+-- and floating @fcmp@ predicates. On the no-NaN subset the unordered float
+-- predicates (@u*@) denote the same Haskell comparison as their ordered (@o*@)
+-- counterparts, and the @u{gt,ge,lt,le}@ spellings are shared with @icmp@'s
+-- unsigned predicates, so a single flat table suffices. @ord@/@uno@ (explicit
+-- NaN tests) are deliberately absent — they are out of subset for now.
 translateCmpType :: String -> String
 translateCmpType str = case str of
   "eq" -> "=="
@@ -36,6 +41,15 @@ translateCmpType str = case str of
   "sge" -> ">="
   "slt" -> "<"
   "sle" -> "<="
+  -- floating-point (fcmp) ordered/unordered predicates
+  "oeq" -> "=="
+  "one" -> "/="
+  "ogt" -> ">"
+  "oge" -> ">="
+  "olt" -> "<"
+  "ole" -> "<="
+  "ueq" -> "=="
+  "une" -> "/="
   _ -> "UNKNOWN CMP"
 
 translateOperator :: String -> String
@@ -56,6 +70,13 @@ translateOperator str = case str of
   -- so `ashr` maps to it directly; `lshr` shares the spelling and stays the
   -- documented signedness limitation (see plans/03-broader-subset.md).
   "ashr" -> " `shiftR` "
+  -- floating-point arithmetic. fadd/fsub/fmul share Haskell's Num operators
+  -- with their integer counterparts; fdiv is true division and frem is C fmod.
+  "fadd" -> " + "
+  "fsub" -> " - "
+  "fmul" -> " * "
+  "fdiv" -> " / "
+  "frem" -> " `mod'` "
   _ -> "UNKNOWN OP"
 
 unpack :: LBS.ByteString -> String
@@ -96,13 +117,6 @@ widthToHsType n
 -- zero-extend rather than sign-extend.
 widthToWordType :: Int -> String
 widthToWordType n = "Word" ++ drop 3 (widthToHsType n)
-
--- | The Haskell type for an LLVM type spelling. @void@ — the only non-integer
--- type in the subset — maps to the unit type @()@, the faithful functional
--- encoding of "no value" (so @ret void@ returns @()@, not a fabricated @0@).
-hsTypeOfLlvm :: String -> String
-hsTypeOfLlvm "void" = "()"
-hsTypeOfLlvm s = maybe "Int" widthToHsType (integerWidth s)
 
 indent :: Int -> String -> String
 indent level str = replicate (level * 2) ' ' ++ str

--- a/src/TypeSystem.hs
+++ b/src/TypeSystem.hs
@@ -13,6 +13,7 @@ module TypeSystem
   , elaborate
   , rho
   , widthOf
+  , isFloating
   ) where
 
 import TranslateAux (widthToHsType, llvmIntWidth)
@@ -49,3 +50,10 @@ rho TyUnit    = "()"
 widthOf :: Ty -> Int
 widthOf (TyInt n) = n
 widthOf t         = error ("widthOf: not an integer type: " ++ show t)
+
+-- | Whether a 'Ty' is an IEEE floating type. Used to pick NaN-faithful codegen
+-- for @fcmp@ (which shares predicate spellings with integer @icmp@).
+isFloating :: Ty -> Bool
+isFloating TyFloat  = True
+isFloating TyDouble = True
+isFloating _        = False

--- a/src/TypeSystem.hs
+++ b/src/TypeSystem.hs
@@ -1,0 +1,51 @@
+-- | The small type discipline that lets the translator handle more than one
+-- value sort. LLVM-IR is explicitly typed, so this is an /elaboration/ (read
+-- LLVM's annotations into 'Ty') plus a /representation map/ ('rho', the only
+-- place a 'Ty' becomes a Haskell type), not type inference.
+--
+-- The lattice is intentionally wider than the integer-only past: 'TyFloat' /
+-- 'TyDouble' are introduced here for floating-point support, and 'TyBool' is
+-- wired in but dormant (i1 still elaborates to @TyInt 1@) so the i1-as-Bool
+-- refinement is a localized follow-up rather than a refactor. See
+-- docs/roadmap/plans/09-floating-point.md.
+module TypeSystem
+  ( Ty(..)
+  , elaborate
+  , rho
+  , widthOf
+  ) where
+
+import TranslateAux (widthToHsType, llvmIntWidth)
+
+-- | The internal type lattice. @TyInt@ carries the /LLVM/ width N; the rounding
+-- up to a representable @IntK@ is deferred to 'rho'.
+data Ty
+  = TyInt Int   -- ^ @iN@ (1..64 in subset)
+  | TyFloat     -- ^ LLVM @float@  — IEEE-754 binary32 — Haskell 'Float'
+  | TyDouble    -- ^ LLVM @double@ — IEEE-754 binary64 — Haskell 'Double'
+  | TyBool      -- ^ i1-as-Bool. Dormant until the boolean-types item.
+  | TyUnit      -- ^ LLVM @void@
+  deriving (Eq, Show)
+
+-- | Elaborate an (already punctuation-stripped) LLVM type spelling into a 'Ty'.
+-- Total: anything off-subset is a loud error rather than a silent fallback.
+elaborate :: String -> Ty
+elaborate "void"   = TyUnit
+elaborate "float"  = TyFloat
+elaborate "double" = TyDouble
+elaborate s        = TyInt (llvmIntWidth s)  -- errors if not an @iN@
+
+-- | The Haskell type a 'Ty' is represented by. Integer widths round /up/ to the
+-- next available 'Data.Int' size (handled by 'widthToHsType').
+rho :: Ty -> String
+rho (TyInt n) = widthToHsType n
+rho TyFloat   = "Float"
+rho TyDouble  = "Double"
+rho TyBool    = "Bool"
+rho TyUnit    = "()"
+
+-- | The bit-width of an integer 'Ty'. Partial: only valid at positions the
+-- subset guarantees integer (the integer side of a conversion).
+widthOf :: Ty -> Int
+widthOf (TyInt n) = n
+widthOf t         = error ("widthOf: not an integer type: " ++ show t)

--- a/test/FloatingSpec.hs
+++ b/test/FloatingSpec.hs
@@ -41,12 +41,33 @@ fdiv = unlines
   , "}"
   ]
 
--- fcmp with an unordered predicate (clang's lowering of a `<=` guard).
+-- fcmp with an unordered predicate (clang's lowering of a `<=` guard). Must be
+-- NaN-faithful: ugt is true when an operand is NaN, so it needs an isNaN guard.
 fcmpUgt :: String
 fcmpUgt = unlines
   [ "define double @h(double %a) {"
   , "  %1 = fcmp ugt double %a, 0.000000e+00"
   , "  ret double %a"
+  , "}"
+  ]
+
+-- fcmp with an ordered predicate: maps to a plain operator (Haskell's < already
+-- yields False on NaN, matching LLVM's ordered semantics) -- no isNaN guard.
+fcmpOlt :: String
+fcmpOlt = unlines
+  [ "define double @o(double %a, double %b) {"
+  , "  %1 = fcmp olt double %a, %b"
+  , "  ret double %a"
+  , "}"
+  ]
+
+-- integer icmp shares the `ugt` spelling but is an unsigned compare with no NaN:
+-- it must stay a plain operator, never an isNaN guard.
+icmpUgt :: String
+icmpUgt = unlines
+  [ "define i32 @c(i32 %a, i32 %b) {"
+  , "  %1 = icmp ugt i32 %a, %b"
+  , "  ret i32 %a"
   , "}"
   ]
 
@@ -121,8 +142,18 @@ spec = parallel $ do
         let out = emit fdiv
         out `shouldSatisfy` isInfixOf " / "
         out `shouldNotSatisfy` isInfixOf "quot"
-      it "maps the unordered fcmp ugt to >" $
-        emit fcmpUgt `shouldSatisfy` isInfixOf " > "
+      it "guards the unordered fcmp ugt with isNaN (NaN-faithful)" $ do
+        let out = emit fcmpUgt
+        out `shouldSatisfy` isInfixOf "isNaN"
+        out `shouldSatisfy` isInfixOf " > "
+      it "leaves an ordered fcmp olt as a plain operator (no isNaN)" $ do
+        let out = emit fcmpOlt
+        out `shouldSatisfy` isInfixOf " < "
+        out `shouldNotSatisfy` isInfixOf "isNaN"
+      it "leaves an integer icmp ugt as a plain operator (no isNaN)" $ do
+        let out = emit icmpUgt
+        out `shouldSatisfy` isInfixOf " > "
+        out `shouldNotSatisfy` isInfixOf "isNaN"
 
     describe "literals" $ do
       it "emits floating literals as explicitly-typed Haskell literals" $

--- a/test/FloatingSpec.hs
+++ b/test/FloatingSpec.hs
@@ -1,0 +1,143 @@
+-- | TDD spec for docs/roadmap/plans/09-floating-point.md.
+--
+-- Pins down the floating-point fragment: @float@\/@double@ map to Haskell
+-- @Float@\/@Double@, the @f*@ instruction family translates with the right
+-- operators/comparisons, the int<->float conversions emit the correct (and
+-- correctly-rounding) coercions, and floating literals are emitted as
+-- explicitly-typed Haskell literals. Drives the real pipeline (lex -> parse ->
+-- translate -> print) and asserts on the emitted Haskell; the end-to-end
+-- bit-exact check lives in test/differential/.
+module FloatingSpec (spec) where
+
+import Test.Hspec
+import Data.List (isInfixOf)
+import qualified Data.ByteString.Lazy.Char8 as BL
+
+import Lexer (runAlex)
+import Parser (parseLLVMIR)
+import Translate (translate)
+import PrintAnf (printProgram)
+
+emit :: String -> String
+emit src = case runAlex (BL.pack src) parseLLVMIR of
+  Left err  -> error ("parse failed: " ++ err)
+  Right ast -> printProgram (translate ast)
+
+-- double arithmetic + a literal operand.
+fadd :: String
+fadd = unlines
+  [ "define double @f(double %a, double %b) {"
+  , "  %1 = fadd double %a, %b"
+  , "  %2 = fmul double %1, 2.000000e+00"
+  , "  ret double %2"
+  , "}"
+  ]
+
+fdiv :: String
+fdiv = unlines
+  [ "define double @g(double %a, double %b) {"
+  , "  %1 = fdiv double %a, %b"
+  , "  ret double %1"
+  , "}"
+  ]
+
+-- fcmp with an unordered predicate (clang's lowering of a `<=` guard).
+fcmpUgt :: String
+fcmpUgt = unlines
+  [ "define double @h(double %a) {"
+  , "  %1 = fcmp ugt double %a, 0.000000e+00"
+  , "  ret double %a"
+  , "}"
+  ]
+
+-- single-precision: float arithmetic must map to Float, not Double.
+floatArith :: String
+floatArith = unlines
+  [ "define float @s(float %a, float %b) {"
+  , "  %1 = fadd float %a, %b"
+  , "  ret float %1"
+  , "}"
+  ]
+
+-- the int<->float conversions, including the rounding-sensitive fptosi.
+sitofpCase :: String
+sitofpCase = unlines
+  [ "define double @i2f(i32 %n) {"
+  , "  %1 = sitofp i32 %n to double"
+  , "  ret double %1"
+  , "}"
+  ]
+
+uitofpCase :: String
+uitofpCase = unlines
+  [ "define double @u2f(i32 %n) {"
+  , "  %1 = uitofp i32 %n to double"
+  , "  ret double %1"
+  , "}"
+  ]
+
+fptosiCase :: String
+fptosiCase = unlines
+  [ "define i32 @f2i(double %x) {"
+  , "  %1 = fptosi double %x to i32"
+  , "  ret i32 %1"
+  , "}"
+  ]
+
+fpextCase :: String
+fpextCase = unlines
+  [ "define double @ext(float %x) {"
+  , "  %1 = fpext float %x to double"
+  , "  ret double %1"
+  , "}"
+  ]
+
+fptruncCase :: String
+fptruncCase = unlines
+  [ "define float @tr(double %x) {"
+  , "  %1 = fptrunc double %x to float"
+  , "  ret float %1"
+  , "}"
+  ]
+
+spec :: Spec
+spec = parallel $ do
+  describe "floating point" $ do
+
+    describe "types and signatures" $ do
+      it "maps double to Double in the signature" $
+        emit fadd `shouldSatisfy` isInfixOf "f :: Double -> Double -> Double"
+      it "maps float to Float in the signature" $
+        emit floatArith `shouldSatisfy` isInfixOf "s :: Float -> Float -> Float"
+      it "annotates double bindings with :: Double" $
+        emit fadd `shouldSatisfy` isInfixOf ":: Double"
+
+    describe "arithmetic and comparison" $ do
+      it "maps fadd/fmul to + and *" $ do
+        let out = emit fadd
+        out `shouldSatisfy` isInfixOf " + "
+        out `shouldSatisfy` isInfixOf " * "
+      it "maps fdiv to / (true division, not quot)" $ do
+        let out = emit fdiv
+        out `shouldSatisfy` isInfixOf " / "
+        out `shouldNotSatisfy` isInfixOf "quot"
+      it "maps the unordered fcmp ugt to >" $
+        emit fcmpUgt `shouldSatisfy` isInfixOf " > "
+
+    describe "literals" $ do
+      it "emits floating literals as explicitly-typed Haskell literals" $
+        emit fadd `shouldSatisfy` isInfixOf "(2.000000e+00 :: Double)"
+
+    describe "conversions" $ do
+      it "sitofp is a plain fromIntegral into the float type" $
+        emit sitofpCase `shouldSatisfy` isInfixOf "fromIntegral"
+      it "uitofp zero-extends through the unsigned word type" $
+        emit uitofpCase `shouldSatisfy` isInfixOf "Word32"
+      it "fptosi truncates toward zero (truncate, not round)" $ do
+        let out = emit fptosiCase
+        out `shouldSatisfy` isInfixOf "truncate"
+        out `shouldSatisfy` isInfixOf ":: Int32"
+      it "fpext widens with float2Double" $
+        emit fpextCase `shouldSatisfy` isInfixOf "float2Double"
+      it "fptrunc narrows with double2Float" $
+        emit fptruncCase `shouldSatisfy` isInfixOf "double2Float"

--- a/test/NameNormalizerSpec.hs
+++ b/test/NameNormalizerSpec.hs
@@ -1,0 +1,35 @@
+-- | Unit spec for NameNormalizer: LLVM identifiers must normalize to valid
+-- Haskell identifiers, stripping every punctuation character the lexer admits
+-- inside a name (sigils, '.', '$', the label colon). A def and its references
+-- must collapse to the same string, which is what makes the generated Haskell
+-- well-scoped.
+module NameNormalizerSpec (spec) where
+
+import Test.Hspec
+import Data.Char (isAlphaNum)
+
+import NameNormalizer
+
+spec :: Spec
+spec = parallel $ do
+  describe "NameNormalizer" $ do
+
+    describe "normalizeName (local registers / block labels)" $ do
+      it "prefixes 'a' and strips the leading % sigil" $
+        normalizeName "%3" `shouldBe` "a3"
+      it "strips '.' so dotted labels become valid identifiers" $
+        normalizeName "%for.cond.cleanup" `shouldBe` "aforcondcleanup"
+      it "strips '$' (an operator char in Haskell)" $
+        normalizeName "%for$body" `shouldBe` "aforbody"
+      it "collapses a label def (trailing colon) to its reference form" $
+        normalizeName "for.cond.cleanup:" `shouldBe` normalizeName "%for.cond.cleanup"
+
+    describe "normalizeGlobal (function names)" $ do
+      it "strips '$' from globals too" $
+        normalizeGlobal "@foo$bar" `shouldBe` "foobar"
+
+    describe "output is always a valid Haskell identifier body" $ do
+      it "leaves only alphanumerics and underscores" $ do
+        let ok s = all (\c -> isAlphaNum c || c == '_') s
+        normalizeName "%a.b$c:" `shouldSatisfy` ok
+        normalizeGlobal "@x$y.z" `shouldSatisfy` ok

--- a/test/differential/run.py
+++ b/test/differential/run.py
@@ -2,23 +2,26 @@
 """Differential testing of the SSA -> ANF translation.
 
 For each example in ``examples/`` we obtain two executables of the *same*
-function and compare them over a fuzzed range of integer inputs:
+function and compare them over a fuzzed range of inputs:
 
   * native    -- clang compiles the LLVM-IR ``.ll`` directly. This is the
                  ground truth: the exact IR we translate, with real iN
-                 wraparound semantics.
+                 wraparound and IEEE-754 semantics.
   * pipeline  -- this project translates the ``.ll`` to Haskell (ANF), which
-                 GHC then compiles. Integers become Haskell ``Int`` (64-bit).
+                 GHC then compiles. Each iN becomes the matching sized Haskell
+                 integer; float/double become Float/Double.
 
 Each trial is classified:
 
   EXACT    native == pipeline
   MISMATCH otherwise -- a genuine divergence.
 
-Since the translation maps each LLVM iN to the matching sized Haskell integer
-(docs/roadmap/bit-width-fidelity.md), wraparound is faithful and every example
-is expected to be bit-for-bit EXACT. Exit status is non-zero iff any MISMATCH is
-found, so this doubles as a CI gate that also catches bit-width regressions.
+Integer results are compared as values; floating results are compared by their
+raw IEEE bit pattern (so the check is exact and NaN-robust). The translation
+maps each iN to the matching sized integer (docs/roadmap/bit-width-fidelity.md)
+and each f-op to its strict-FP Haskell counterpart, so every example is expected
+to be bit-for-bit EXACT. Exit status is non-zero iff any MISMATCH is found, so
+this doubles as a CI gate that also catches bit-width / FP regressions.
 
 The corpus is *auto-discovered*: ``discover`` scans ``examples/*.ll`` and reads
 each function's signature off its ``define`` line, so dropping a new ``.ll`` in
@@ -45,17 +48,36 @@ EXAMPLES = os.path.join(ROOT, "examples")
 
 # C type for each LLVM type we accept. Integer widths are read through C's
 # ``int``/``long long``; an ``i1`` (0/1 bool return) rides in an ``int`` too.
-# ``void`` carries no value: a void case only certifies both sides build and run
-# (see ``run_case``). Any other type (ptr, float, ...) is outside the subset, so
+# ``float``/``double`` are the IEEE types; results are compared by their raw bit
+# pattern (see ``build_native``/``build_pipeline``), so the comparison is exact
+# and NaN-robust. ``void`` carries no value: a void case only certifies both
+# sides build and run. Any other type (ptr, ...) is outside the subset, so
 # ``discover`` skips functions that mention it.
 INT_C = {"i1": "int", "i8": "int", "i16": "int", "i32": "int", "i64": "long long"}
-CTYPE = {**INT_C, "void": "void"}
+FLOAT_C = {"float": "float", "double": "double"}
+NUM_C = {**INT_C, **FLOAT_C}
+CTYPE = {**NUM_C, "void": "void"}
+
+
+def is_float(t):
+    return t in FLOAT_C
+
 
 # Default fuzz range per integer width. The i32 span deliberately crosses the
 # i32 overflow boundary -- so x*x and triangular sums wrap, exercising bit-width
 # fidelity -- while staying clear of INT_MIN (which is llvm.abs's poison case).
+# Floating arguments are sampled uniformly from a moderate magnitude (kept away
+# from NaN/Inf/overflow); both sides receive bit-identical inputs because the
+# value is passed as a round-tripping decimal and parsed by matched routines.
 DEFAULT_I32 = (-100_000, 100_000)
 DEFAULT_RANGE = {"i64": (-(1 << 40), 1 << 40)}
+DEFAULT_FLOAT = (-1.0e3, 1.0e3)
+
+
+def sample_one(r, t):
+    if is_float(t):
+        return repr(r.uniform(*DEFAULT_FLOAT))
+    return r.randint(*DEFAULT_RANGE.get(t, DEFAULT_I32))
 
 
 def case(ll, func, args, ret, sampler, note=""):
@@ -63,9 +85,9 @@ def case(ll, func, args, ret, sampler, note=""):
 
 
 def default_sampler(arg_types):
-    """A wide signed sampler derived purely from the argument widths."""
+    """A wide sampler derived purely from the argument types (int or float)."""
     def sample(r):
-        return tuple(r.randint(*DEFAULT_RANGE.get(t, DEFAULT_I32)) for t in arg_types)
+        return tuple(sample_one(r, t) for t in arg_types)
     return sample
 
 
@@ -137,7 +159,7 @@ def discover():
         if any(func == "main" for func, _, _ in defs):
             continue
         for func, args, ret in defs:
-            if ret not in CTYPE or any(a not in INT_C for a in args):
+            if ret not in CTYPE or any(a not in NUM_C for a in args):
                 continue
             sampler, note = OVERRIDES.get((ll, func), (default_sampler(args), ""))
             cases.append(case(ll, func, args, ret, sampler, note))
@@ -151,19 +173,42 @@ def sh(cmd, **kw):
     return subprocess.run(cmd, capture_output=True, text=True, **kw)
 
 
+def _parse_arg(t, idx):
+    """C expression parsing argv[idx] into the parameter type ``t``.
+
+    Floats parse with strtof/strtod (single decimal->IEEE rounding, matching the
+    Haskell ``read``); integers go through strtoll.
+    """
+    if t == "float":
+        return f"strtof(argv[{idx}], 0)"
+    if t == "double":
+        return f"strtod(argv[{idx}], 0)"
+    return f"({CTYPE[t]}) strtoll(argv[{idx}], 0, 10)"
+
+
 def build_native(c, workdir):
     """clang-compile the .ll plus a generated C driver; return the exe path."""
     ret_c = CTYPE[c["ret"]]
     params = ", ".join(CTYPE[a] for a in c["args"])
-    parse = ", ".join(f"({CTYPE[a]}) strtoll(argv[{n + 1}], 0, 10)"
-                      for n, a in enumerate(c["args"]))
+    parse = ", ".join(_parse_arg(a, n + 1) for n, a in enumerate(c["args"]))
     if c["ret"] == "void":
         # No value to print; call it and emit the same marker the pipeline does.
         body = f'    {c["func"]}({parse});\n    printf("()\\n");'
+    elif c["ret"] == "double":
+        # Print the raw IEEE bit pattern so the comparison is exact / NaN-robust.
+        body = (f'    double _r = {c["func"]}({parse});\n'
+                '    uint64_t _u; memcpy(&_u, &_r, 8);\n'
+                '    printf("%llu\\n", (unsigned long long) _u);')
+    elif c["ret"] == "float":
+        body = (f'    float _r = {c["func"]}({parse});\n'
+                '    uint32_t _u; memcpy(&_u, &_r, 4);\n'
+                '    printf("%u\\n", (unsigned) _u);')
     else:
         body = f'    printf("%lld\\n", (long long) {c["func"]}({parse}));'
     drv = f"""#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
 extern {ret_c} {c['func']}({params});
 int main(int argc, char **argv) {{
 {body}
@@ -190,26 +235,41 @@ def build_pipeline(c, workdir):
     if r.returncode != 0 or not os.path.exists(hs):
         raise RuntimeError("translation failed:\n" + r.stderr)
     src = open(hs).read()
-    # getArgs must be imported with the other imports, before any definition.
-    src = src.replace("import Data.Bits",
-                      "import Data.Bits\nimport System.Environment (getArgs)", 1)
-    # The translated function is now bit-width-typed (iN -> IntN), so feed it
-    # fromIntegral-converted args and widen the signed IntN result back to
-    # Integer for printing -- this matches native's signed (long long) cast.
-    # A nullary LLVM function translates to a `() -> _` lambda, so pass unit.
-    argv = (" ".join(f"(fromIntegral (xs!!{n}))" for n in range(len(c["args"])))
+    # getArgs and the bit-cast helpers must be imported with the other imports,
+    # before any definition.
+    src = src.replace(
+        "import Data.Bits",
+        "import Data.Bits\n"
+        "import System.Environment (getArgs)\n"
+        "import GHC.Float (castFloatToWord32, castDoubleToWord64)", 1)
+    # Each argument is read at the type its position expects: a float/double
+    # parameter reads as Float/Double (single decimal->IEEE rounding, matching
+    # the C strtof/strtod), an integer parameter as Integer then fromIntegral
+    # into its sized IntN. A nullary LLVM function takes a `()`.
+    def arg_expr(n, t):
+        if t == "float":
+            return f"(read (as!!{n}) :: Float)"
+        if t == "double":
+            return f"(read (as!!{n}) :: Double)"
+        return f"(fromIntegral (read (as!!{n}) :: Integer))"
+    argv = (" ".join(arg_expr(n, t) for n, t in enumerate(c["args"]))
             if c["args"] else "()")
+    call = f"{c['func']} {argv}"
     if c["ret"] == "void":
         # `f ()` has type () here; its Show instance prints "()" -- the same
         # marker native emits. Comparing these certifies compile-and-run.
-        result = f"print ({c['func']} {argv})"
+        result = f"print ({call})"
+    elif c["ret"] == "double":
+        # Same raw IEEE bit pattern the native side prints.
+        result = f"print (castDoubleToWord64 ({call}))"
+    elif c["ret"] == "float":
+        result = f"print (castFloatToWord32 ({call}))"
     else:
-        result = f"print (fromIntegral ({c['func']} {argv}) :: Integer)"
+        result = f"print (fromIntegral ({call}) :: Integer)"
     src += (
         "\nmain :: IO ()\n"
         "main = do\n"
         "  as <- getArgs\n"
-        "  let xs = map read as :: [Integer]\n"
         f"  {result}\n"
     )
     open(hs, "w").write(src)

--- a/test/differential/run.py
+++ b/test/differential/run.py
@@ -73,9 +73,17 @@ DEFAULT_I32 = (-100_000, 100_000)
 DEFAULT_RANGE = {"i64": (-(1 << 40), 1 << 40)}
 DEFAULT_FLOAT = (-1.0e3, 1.0e3)
 
+# Edge values for floating arguments. NaN and +/-Inf are spelled the way both C
+# strtod and Haskell read accept; they exercise the NaN-faithful fcmp codegen
+# (e.g. newton_sqrt's `fcmp ugt` guard) and IEEE infinity arithmetic. Drawn ~15%
+# of the time so a normal -n run hits them several times per argument.
+FLOAT_EDGES = ["NaN", "Infinity", "-Infinity", "0.0", "-0.0", "1.0", "-1.0"]
+
 
 def sample_one(r, t):
     if is_float(t):
+        if r.random() < 0.15:
+            return r.choice(FLOAT_EDGES)
         return repr(r.uniform(*DEFAULT_FLOAT))
     return r.randint(*DEFAULT_RANGE.get(t, DEFAULT_I32))
 
@@ -195,20 +203,23 @@ def build_native(c, workdir):
         # No value to print; call it and emit the same marker the pipeline does.
         body = f'    {c["func"]}({parse});\n    printf("()\\n");'
     elif c["ret"] == "double":
-        # Print the raw IEEE bit pattern so the comparison is exact / NaN-robust.
+        # Print the raw IEEE bit pattern (exact comparison), but canonicalise any
+        # NaN to a "nan" sentinel: a NaN result is faithful regardless of its
+        # payload/sign bits, which clang and GHC need not agree on.
         body = (f'    double _r = {c["func"]}({parse});\n'
-                '    uint64_t _u; memcpy(&_u, &_r, 8);\n'
-                '    printf("%llu\\n", (unsigned long long) _u);')
+                '    if (isnan(_r)) printf("nan\\n");\n'
+                '    else { uint64_t _u; memcpy(&_u, &_r, 8); printf("%llu\\n", (unsigned long long) _u); }')
     elif c["ret"] == "float":
         body = (f'    float _r = {c["func"]}({parse});\n'
-                '    uint32_t _u; memcpy(&_u, &_r, 4);\n'
-                '    printf("%u\\n", (unsigned) _u);')
+                '    if (isnan(_r)) printf("nan\\n");\n'
+                '    else { uint32_t _u; memcpy(&_u, &_r, 4); printf("%u\\n", (unsigned) _u); }')
     else:
         body = f'    printf("%lld\\n", (long long) {c["func"]}({parse}));'
     drv = f"""#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include <math.h>
 extern {ret_c} {c['func']}({params});
 int main(int argc, char **argv) {{
 {body}
@@ -259,11 +270,12 @@ def build_pipeline(c, workdir):
         # `f ()` has type () here; its Show instance prints "()" -- the same
         # marker native emits. Comparing these certifies compile-and-run.
         result = f"print ({call})"
-    elif c["ret"] == "double":
-        # Same raw IEEE bit pattern the native side prints.
-        result = f"print (castDoubleToWord64 ({call}))"
-    elif c["ret"] == "float":
-        result = f"print (castFloatToWord32 ({call}))"
+    elif c["ret"] in ("double", "float"):
+        # Same raw IEEE bit pattern the native side prints, with the matching
+        # "nan" canonicalisation (payload/sign of a NaN result is unspecified).
+        cast = "castDoubleToWord64" if c["ret"] == "double" else "castFloatToWord32"
+        result = (f"let _r = {call} in "
+                  f'if isNaN _r then putStrLn "nan" else print ({cast} _r)')
     else:
         result = f"print (fromIntegral ({call}) :: Integer)"
     src += (
@@ -293,9 +305,10 @@ def run_int(exe, argtuple):
 
 
 def run_case(c, trials, rng):
-    # ``void`` has no value to compare, so we compare stdout markers as strings;
-    # a match means both sides built and ran. Otherwise compare integer results.
-    runner = run_out if c["ret"] == "void" else run_int
+    # Integer results compare as values; ``void`` and floating results compare as
+    # stdout strings (a void marker, or a bit-pattern / "nan" sentinel). A match
+    # for void means both sides built and ran.
+    runner = run_int if c["ret"] in INT_C else run_out
     with tempfile.TemporaryDirectory() as wd:
         native = build_native(c, wd)
         pipeline = build_pipeline(c, wd)


### PR DESCRIPTION
## What

Accepts the **pure floating-point fragment** of LLVM-IR (`float`/`double` and the `f*` instruction family) and translates it faithfully to Haskell `Float`/`Double`. Implements [`docs/roadmap/09-floating-point.md`](docs/roadmap/09-floating-point.md) (plan in [`plans/09-floating-point.md`](docs/roadmap/plans/09-floating-point.md)).

## Why it's more than table rows

Floating point is the first feature that breaks the "every value is an integer" assumption baked into `Translate`, `PrintAnf`, and the string-typed `Anf` AST. The core of this PR is a small **type discipline** introduced once, in a shape the next roadmap item (i1-as-`Bool`) drops into with almost no new code.

## Changes

- **New `src/TypeSystem.hs`** — the `Ty` lattice (`TyInt`/`TyFloat`/`TyDouble`/`TyBool`/`TyUnit`), `elaborate` (total, **errors off-subset** — replaces the old silent `"Int"` fallback) and the representation map `rho`. `Anf` now carries `Ty` instead of `String`; `ConvOp` carries source/target `Ty`; `Value` gained `FConst`.
- **FP surface** — `fadd/fsub/fmul/fdiv/frem`, `fcmp` (ordered **and** unordered predicates), `sitofp/uitofp/fptosi/fptoui/fpext/fptrunc`, decimal float literals, and `nneg`/fast-math flag skips.
- **Correct semantics** — `fptosi`/`fptoui` round toward zero (`truncate`); `uitofp`/`zext` go via the unsigned word type; `fpext`/`fptrunc` use the bit-exact `GHC.Float` primitives.
- **`TyBool` wired but dormant** (i1 still elaborates to `TyInt 1`), so the boolean refinement (#10) is a localized switch.
- **Pre-existing lexer fix** — named block labels with dots (`for.cond.cleanup:`) now lex; the integer corpus only used numeric labels.

## Tests

- `test/FloatingSpec.hs` unit-specs the type system + codegen.
- Six research-classic examples added: **rump** (catastrophic cancellation), **muller** (recurrence diverging from ℝ), **twosum** (error-free transform), **kahan_sum** (compensated summation), **newton_sqrt**, **logistic**.
- The differential harness is extended for float signatures and **bit-pattern** comparison (exact + NaN-robust) and certifies the **whole corpus (26 functions) bit-for-bit exact** against native clang — integer examples unchanged, including the adversarial Rump/Muller cases.

`stack test` → 46 examples, 0 failures. `python3 test/differential/run.py` → all exact.

## Deferred (per plan §11)

Hex IEEE float literals (corpus is all decimal), `ord`/`uno` NaN-test predicates, and the standalone `validate` pass (types proved locally recoverable, so no global Γ was needed for correctness).