### PR TITLE
Annotated ANF AST + pluggable backend seam (roadmap #04)

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -9,12 +9,34 @@ import qualified Data.ByteString.Lazy as BL
 import System.Environment (getArgs)
 
 import Dominance (dominances, buildGraphs)
-import PrintAnf (printProgram)
+import Effect (annotate)
+import Backend (Backend, runBackend)
+import PrintAnf (haskellBackend)
+import AnnotDump (annotDumpBackend)
+
+-- | The output backends selectable with @--backend NAME@. The Haskell source
+-- printer is the default and first; 'annotDumpBackend' is the annotation-reading
+-- debug backend that proves the backend seam (see
+-- docs/roadmap/plans/04-annotated-anf-ast.md).
+backends :: [Backend]
+backends = [haskellBackend, annotDumpBackend]
 
 output :: [String] -> String -> IO ()
 output out str = case out of
   ("-o":outFile:_) -> writeFile outFile str
   _ -> putStrLn str
+
+-- | Run the translation pipeline (parse → translate → annotate → render) with
+-- the chosen backend, writing to the requested sink.
+translateWith :: String -> FilePath -> [String] -> IO ()
+translateWith backendId file out = do
+  s <- BL.readFile file
+  case runAlex s parseLLVMIR of
+    Left err -> putStrLn err
+    Right ast ->
+      case runBackend backends backendId (annotate (translate ast)) of
+        Left unknown -> putStrLn ("Unknown backend: " ++ unknown)
+        Right result -> output out result
 
 main :: IO ()
 main = do
@@ -37,11 +59,6 @@ main = do
           let doms = dominances g
           let result = concatMap plotGraph doms
           output out result
-    (file:out) -> do
-      s <- BL.readFile file
-      case runAlex s parseLLVMIR of
-        Left err -> putStrLn err
-        Right ast -> do
-          let anf = translate ast
-          output out (printProgram anf)
-    [] -> putStrLn "Usage: stack run -- [--dominance-viz | --graph-viz] <file.ll> [-o <output-file>]"
+    ("--backend":backendId:file:out) -> translateWith backendId file out
+    (file:out) -> translateWith "haskell" file out
+    [] -> putStrLn "Usage: stack run -- [--dominance-viz | --graph-viz | --backend NAME] <file.ll> [-o <output-file>]"

--- a/docs/roadmap/04-annotated-anf-ast.md
+++ b/docs/roadmap/04-annotated-anf-ast.md
@@ -3,13 +3,39 @@ type: refactor
 title: Annotated ANF AST with multiple backends
 impact: medium
 effort: medium
-status: proposed
+status: done
 ---
 
 Today `Translate` targets `Anf.hs` and `PrintAnf` emits Haskell text; there
 are no annotation slots. Refactor so `Anf` can carry metadata (effects, types)
 and `PrintAnf` becomes one of several backends.
 
-Enabler for [effect-inference](effect-inference.md) and
-[monadic-effects-translation](monadic-effects-translation.md); not valuable on
+Enabler for [effect-inference](05-effect-inference.md) and
+[monadic-effects-translation](06-monadic-effects-translation.md); not valuable on
 its own.
+
+## Findings (post-implementation)
+
+Full write-up in [`plans/04-annotated-anf-ast.md`](plans/04-annotated-anf-ast.md);
+the points that change how the *next* items proceed:
+
+- **The "types" half of the premise was already done.** Item
+  [09](09-floating-point.md) had already replaced `Anf`'s string type slots with
+  a first-class `Ty`. So 04's real scope was only the *derived*-annotation slot
+  (effects) plus the backend seam — `Ty` stays constructor data (it directs
+  codegen; it is not erasable metadata) and was deliberately **not** folded into
+  the annotation.
+- **Uniform parameterisation was the load-bearing decision.** Adding the
+  annotation to *every* node (mirroring `Ast a`) and deriving `Functor` +
+  `Foldable` means erasure, relabelling and effect-aggregation are all free —
+  #05's bottom-up join is a `foldMap`, not a bespoke traversal. The cost (unused
+  labels on leaf `Value`/`BinOp` nodes) is harmless.
+- **The `docs/{gcd,prime,safe_div}` goldens are NOT a byte-exact oracle.** Each
+  differs from live output by one trailing blank line, and this is pre-existing
+  on `main` (live output is identical to `main`). The plan names golden-diff as
+  the primary regression gate — for #05/#06 the trustworthy oracle is "diff
+  against `main`'s output" + the differential harness, not the `docs/` goldens.
+  Worth regenerating those goldens at some point.
+- **Forward-compat contract verified.** #05 is now a body-only change to
+  `Effect.annotate` (+ richer `Effect`); #06 is one new `Backend` value reading
+  the `Effect` label. Neither needs to touch `Anf`'s structure or `Translate`.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -15,5 +15,5 @@ low / medium / high / godmode (the hardest research jumps).
 | 03 | [Widen the accepted LLVM-IR subset](03-broader-subset.md) | enhancement | medium | medium | done |
 | 09 | [Floating-point support (pure, two-type story)](09-floating-point.md) | enhancement | medium | medium | done |
 | 10 | [i1-aware Bool (idiomatic boolean output)](10-boolean-types.md) | enhancement | low | medium | done |
-| 04 | [Annotated ANF AST with multiple backends](04-annotated-anf-ast.md) | refactor | medium | medium | proposed |
+| 04 | [Annotated ANF AST with multiple backends](04-annotated-anf-ast.md) | refactor | medium | medium | done |
 | 07 | [Source-to-source optimizations on ANF](07-anf-optimizations.md) | research | low | high | proposed |

--- a/docs/roadmap/plans/04-annotated-anf-ast.md
+++ b/docs/roadmap/plans/04-annotated-anf-ast.md
@@ -1,0 +1,465 @@
+---
+type: plan
+title: Implementation plan — annotated ANF AST and the algebra of backends
+tracks: 04-annotated-anf-ast.md
+status: done
+---
+
+## Outcome
+
+Landed. `src/Anf.hs` is now parameterised over an annotation type `a` (uniformly,
+mirroring `Ast a`) and derives `Functor`/`Foldable`, giving label rewriting,
+erasure (`Anf.erase = fmap (const ())`) and aggregation (`foldMap`) for free.
+`Translate` produces the bare `Anf.Program ()`; a new `src/Effect.hs` carries the
+`Effect` join-semilattice (`Pure`/`⊥`, lawful `Semigroup`/`Monoid`) and the
+`annotate :: Program () -> Program Effect` pass (currently the constant-`Pure`
+baseline — exactly #05's sanity milestone). A new `src/Backend.hs` makes a backend
+a record of functions (`backendName`, `render`); `PrintAnf` is the first
+instance (`haskellBackend`), made annotation-blind (`printProgram :: Program a ->
+String`), and a second, annotation-*reading* backend `src/AnnotDump.hs` proves
+the seam. `app/Main.hs` runs `parse → translate → annotate → render` and gained a
+`--backend NAME` flag.
+
+`Ty` stayed constructor data (it directs codegen; not folded into the annotation
+— plan §0/D2). Verification matched §6: the whole corpus is **byte-identical to
+`main`** (confirmed by direct output diff on `gcd`/`prime`/`safe_div`, not just
+the stale goldens) and still **bit-for-bit exact** through the differential
+harness (24 functions); `test/AnnotatedSpec.hs` encodes T1 (annotation
+transparency / naturality), T2 (pipeline factorisation), the seam proof (a second
+backend emits different text and surfaces the `Pure` label the Haskell backend
+never prints), the all-`Pure` baseline (`all (== Pure)` over the `Foldable`
+instance), and the lattice laws. Build is warning-clean under the full `-W` set;
+70 examples / 0 failures.
+
+The forward-compat contract (§7) holds as designed: #05 is now a *body* change to
+`Effect.annotate` (+ richer `Effect`) with no signature/pipeline churn, and #06 is
+one new `Backend` value reading the `Effect` label — neither touches `Anf`'s
+structure or `Translate`.
+---
+
+Tracks [`../04-annotated-anf-ast.md`](../04-annotated-anf-ast.md). Goal: give the
+output AST a place to carry *derived* analysis results (effects first, anything
+later) and turn `PrintAnf` from *the* output into *one* output among several,
+without changing a single byte of the Haskell currently emitted.
+
+This item is a **refactor**, not a feature: it adds no new accepted LLVM-IR and
+no new generated code on the existing corpus. Its entire value is structural — it
+is the seam that the two godmode research items,
+[`../05-effect-inference.md`](../05-effect-inference.md) (compute *where* effects
+live) and [`../06-monadic-effects-translation.md`](../06-monadic-effects-translation.md)
+(emit monadic code *there*), both plug into. The roadmap is explicit that it is
+"not valuable on its own"; the discipline of this plan is therefore to (a) state
+the theory cleanly enough that the paper can reuse it, and (b) define a
+verification that proves the refactor is *behaviour-preserving* and the new seam
+is *real*, since there is no user-visible feature to demo.
+
+---
+
+## 0. What item 09 already did, and what is left
+
+The roadmap line says "so `Anf` can carry metadata (effects, types)." Half of
+that is already true. [`09-floating-point`](09-floating-point.md) replaced the
+string type slots in `Anf` with a first-class `Ty` and centralised the type
+discipline in `src/TypeSystem.hs`. So **types are not metadata in this codebase —
+they are intrinsic structural fields that *direct codegen*** (`rho`, `coerce`,
+NaN-faithful `fcmp`, …). They are not optional and must not be folded into a
+generic annotation slot, or the printer loses the information it needs.
+
+That distinction is the spine of this plan and is itself a theoretical point
+(§2.1): there are two kinds of decoration on the tree —
+
+- **Essential / structural** (`Ty`): part of the term's meaning, consumed by
+  *every* backend, present from construction. Already done.
+- **Derived / analytic** (effects, and future analyses): computed by a *pass*
+  over an already-built term, consumed by *some* backends, absent until inferred.
+  This is what 04 must add.
+
+So 04 reduces to exactly two moves:
+
+1. **A generic annotation parameter** on `Anf`, mirroring how `Ast a` carries a
+   `Range`, so a pass can decorate the tree with derived facts (§2, §4).
+2. **A backend abstraction** so the same annotated tree can be rendered more than
+   one way, with the current printer as the first instance (§3, §4).
+
+---
+
+## 1. Where the current design stops being enough
+
+- `src/Anf.hs` is **monomorphic**. `data Decl = DeclBinOp String Ty BinOp | …`
+  has nowhere to write "this binding is pure / may trap / calls an unknown
+  function." [`05-effect-inference`](../05-effect-inference.md) needs that slot at
+  *binding*, *block*, and *function* granularity; there is currently no slot at
+  any granularity.
+- `src/PrintAnf.hs` **is** the output: `printProgram :: Program -> String` is
+  called directly from `app/Main.hs`. There is no notion of "a backend." The
+  monadic translation in [`06`](../06-monadic-effects-translation.md) is a
+  *different rendering* of the same term (`do { x <- … }` where today we emit
+  `let x = … in`), but the current shape forces it to be either a fork of
+  `PrintAnf` or a pile of conditionals inside it.
+- `Translate` builds the fully concrete tree and hands it straight to the
+  printer. There is no point in the pipeline where an analysis pass could run
+  between construction and rendering, because the tree has no slot for the pass
+  to write into.
+
+Note the asymmetry with the *input* side: `Ast a` is already parameterised over
+an annotation (`Range`) and even derives `Foldable` over it (`src/Ast.hs:1`).
+The output side never got the same treatment because, until effects, nothing
+needed to decorate it. This plan brings `Anf` up to the same standard as `Ast`.
+
+---
+
+## 2. Theoretical foundation: decorated terms
+
+### 2.1 Two decorations, one of them new
+
+Formally, treat the ANF abstract syntax as a functor `A` whose fixed point
+`μA` is the set of ANF terms. Item 09 baked the type assignment into `μA`
+itself (every former carries its `Ty`), because types are *needed to define the
+denotation* `⟦·⟧` of an ANF term — a `DeclBinOp` over `TyDouble` and one over
+`TyInt 32` denote different functions. Types are therefore not an annotation;
+they are constructor data.
+
+An **annotation**, by contrast, is extra data hung on each node that does *not*
+change `⟦·⟧`. The classic way to model it is the **cofree comonad** `Cofree A α`,
+the type of `A`-trees every node of which additionally carries a label of type
+`α`. Two standard facts make this the right frame:
+
+- `Cofree A α` is a `Functor` in `α`: `fmap g` relabels every node, structure
+  untouched. In particular `() <$ t` **erases** all labels.
+- It is a `Comonad`: `extract` reads the root label; `extend` recomputes every
+  node's label from its whole subtree — which is exactly the shape of a
+  *bottom-up effect analysis* (a node's effect is the join of its children's).
+
+We do **not** import `Control.Comonad.Cofree` or the `recursion-schemes`
+package — that machinery is overkill for an undergraduate codebase and would
+obscure the algorithm. Instead we realise the *same* idea the way `Ast` already
+does it: **add a final type parameter `a` to every `Anf` datatype and derive
+`Functor` and `Foldable`** (§4.1). `Anf.Program a` is then exactly `Cofree A a`
+specialised and unrolled, with:
+
+- `fmap` (from `DeriveFunctor`) = relabelling / erasure (`fmap (const ()) p`),
+- `foldMap` (from `DeriveFoldable`) = aggregate every label, e.g. "the join of
+  all effects in this function" for free.
+
+The base instantiation `Anf.Program ()` is the unlabelled tree and must render
+**byte-identical** to today's output — that is the regression theorem (§5, §6).
+
+### 2.2 The annotation payload: an effect lattice
+
+What 05 will write into the slot is an **effect**. State it now (even though 04
+only ships the trivial element) so the slot has the right algebraic shape and 05
+does not have to re-parameterise:
+
+> Effects form a bounded **join-semilattice** `(E, ⊔, ⊥)`. `⊥ = Pure`; `e₁ ⊔ e₂`
+> is "exhibits both effects." For the current pure subset the only inhabited
+> point is `⊥`, so the baseline analysis labels every node `Pure` — which is
+> precisely 05's stated sanity milestone ("every function infers effect-free").
+
+The lattice (not just a set) matters because the analysis is a **fold up the
+dominator-tree-shaped term**: a block's effect is the join of its bindings' and
+its successors' effects; a function's is the join over its blocks'. `foldMap`
+into the `Semigroup` `(E, ⊔)` (with `mempty = ⊥` as `Monoid`) gives that
+aggregation directly from the `Foldable` instance — the reason §2.1 insists on
+deriving `Foldable`. The concrete `data Effect` and the inference live in 05;
+04 ships only the `Pure`/`⊥` carrier and the plumbing.
+
+### 2.3 Backends as algebras over the term
+
+A backend is a function `μA → R` (`R = String` today). The principled name for a
+structurally-recursive such function is an **`A`-algebra** `A R → R` folded by a
+catamorphism `cata :: (A r -> r) -> μA -> r`. `PrintAnf` is already this fold
+written by hand (each `print*` handles one constructor and recurses). The
+theoretical content of "multiple backends" is therefore:
+
+> Fix the carrier `μA`. Each backend is one algebra. The Haskell printer, a
+> future C printer, the monadic printer of [`06`](../06-monadic-effects-translation.md),
+> and a debug pretty-printer are four algebras over the *same* term. Adding a
+> backend never touches the term or the other backends — the open/closed
+> property we are buying.
+
+We will **not** rewrite `PrintAnf` as an explicit `cata` (again: avoid
+`recursion-schemes`); the hand-written recursion *is* the algebra. What we add
+is the *interface* that names "an algebra producing output" so backends are
+interchangeable and selectable (§3, §4.3).
+
+### 2.4 The two theorems this refactor must respect
+
+The translation theorem from the [09 plan](09-floating-point.md) (§3.1, "`F` is
+type-preserving") is about the *typed* term and is **unaffected**: `Ty` stays
+constructor data, so `F` still lands in the same typed language. Two *new*,
+small theorems pin the refactor down and double as its test oracle (§6):
+
+> **(T1 — Annotation transparency / naturality.)** Let `B` be the Haskell
+> backend and `p : Anf.Program a` any annotated program. Then
+> `B(p) = B(fmap (const ()) p)`. I.e. the Haskell backend factors through
+> erasure: annotations never reach the emitted text.
+>
+> *Why it holds:* `B`'s clauses pattern-match only on constructors and `Ty`
+> fields, never on the annotation. Mechanically true once the slot is added and
+> ignored. This is what guarantees the corpus output is unchanged.
+
+> **(T2 — Pipeline factorisation.)** The old `translate` then `printProgram`
+> equals the new `render Haskell ∘ annotate ∘ translate'` on every input, where
+> `translate' = fmap (const ()) ∘ … ` produces the unlabelled term and
+> `annotate` is the (currently trivial, all-`Pure`) effect pass.
+>
+> *Why it holds:* `annotate` only writes labels (changes `a`, not structure),
+> and by T1 the Haskell backend ignores labels. So inserting `annotate` is
+> observationally invisible on the Haskell backend — but it is the hook 05/06
+> need.
+
+T1 is "the refactor didn't change the output"; T2 is "the new pass slot is wired
+in and inert." Together they are the precise sense in which a behaviour-preserving
+refactor *can* be verified despite having no visible feature (§6).
+
+---
+
+## 3. Design decisions to settle before coding
+
+These are the choices that shape the diff; the recommendation in each case is
+the one the rest of the plan assumes.
+
+**D1 — Annotation granularity: uniform vs. selective.** Either parameterise
+*every* `Anf` datatype over `a` (uniform, mirrors `Ast`), or add a slot only to
+`Function`/`Lambda`/`Decl` (the nodes 05 labels). *Recommend uniform.* It mirrors
+`Ast a` exactly (one idiom in the codebase, not two), and — decisively — it lets
+us `deriving (Functor, Foldable)` and get erasure (T1) and effect-aggregation
+(§2.2) for free. Selective slots would need hand-written traversals. The cost is
+annotations on a few nodes nothing reads (`Value`, `BinOp`); harmless.
+
+**D2 — Keep `Ty` as constructor data (do *not* move it into the annotation).**
+Per §0/§2.1, `Ty` directs codegen and is consumed by every backend; it is not
+optional metadata. Folding it into `a` would force every backend to assume a
+type-bearing annotation and would break the clean "annotation = derived,
+erasable" story (T1 would be false). *Recommend: `Ty` stays where 09 put it.*
+
+**D3 — Backend interface shape.** A lightweight `Backend` typeclass with one
+method `render :: Program Effect -> String`, vs. a record of functions, vs. a
+plain `data Target = …` dispatched in `Main`. *Recommend the typeclass* (one
+instance per backend module; §4.3). Make every backend's signature take the
+*annotated* `Program Effect` so the pipeline is single and uniform; the Haskell
+backend is polymorphic/ignores the label (T1). This couples nothing — the
+Haskell backend does not depend on 05 — while giving 06's monadic backend the
+annotation it needs from the same entry point.
+
+**D4 — Always run `annotate`, even while trivial.** The pipeline becomes
+`translate (→ Program ())` → `annotate (→ Program Effect)` → `render`. Running
+the (all-`Pure`) pass now, rather than when 05 lands, is what makes T2 testable
+today and means 05 is a *body* change to `annotate`, not a *pipeline* change.
+
+---
+
+## 4. Implementation, file by file
+
+### 4.1 `src/Anf.hs` — add the parameter, derive the instances
+
+- Add a final type parameter `a` to every datatype: `Program a`, `Function a`,
+  `Lambda a`, `Expr a`, `Decl a`, `ConvOp a`, `Select a`, `Icmp a`, `Flow a`,
+  `BinOp a`, `Call a`, `IfThenElse a`, `Value a`, `ArgumentDef a`.
+- The label sits on the nodes an analysis cares about; for uniformity (D1) put
+  one `a` field on each *recursive* node. Concretely the load-bearing ones:
+  `Function`, `Lambda` (a block — the natural unit of per-block purity), and each
+  `Decl` (per-binding effect). Leaf-ish nodes (`Value`, `BinOp`) still take `a`
+  to keep the `Functor`/`Foldable` derivation total, even though nothing reads
+  them — same as `Range` sits on every `Ast` node today.
+- `{-# LANGUAGE DeriveFunctor, DeriveFoldable #-}`; `deriving (Show, Eq, Functor,
+  Foldable)`. `Foldable` requires `a` to be the *last* parameter and every
+  recursive position to thread it — the uniform scheme guarantees this.
+- Export nothing new beyond the now-parameterised constructors.
+
+This is the bulk of the mechanical churn; it touches signatures everywhere `Anf.`
+types are named but is otherwise rote.
+
+### 4.2 `src/Translate.hs` — produce `Program ()`
+
+- `translate :: Ast.Program Range -> Anf.Program ()`. Every `Anf.` constructor
+  application gains a `()` in the annotation slot. Nothing else changes — the
+  dominator-tree walk, φ→λ-args, branch→tail-call, and `Ty` elaboration are all
+  untouched. `Ty` continues to flow exactly as today (§0/D2).
+- Optionally provide `Functor`-based helpers, but `()` literals at each site are
+  simplest and keep the walk readable.
+
+### 4.3 New: the backend abstraction
+
+- New module `src/Backend.hs`:
+
+  ```haskell
+  class Backend b where
+    backendName :: b -> String          -- for the CLI / errors
+    render      :: b -> Anf.Program Effect -> String
+  ```
+
+  (`Effect` imported from the new `Effect` module, §4.5; while trivial it is a
+  one-constructor `Pure`.)
+
+- `src/PrintAnf.hs` becomes the **Haskell backend**: keep all current code, add
+
+  ```haskell
+  data Haskell = Haskell
+  instance Backend Haskell where
+    backendName _ = "haskell"
+    render _ = printProgram        -- printProgram now :: Program a -> String
+  ```
+
+  The only change to the printer body is the type: `printProgram :: Program a ->
+  String` (polymorphic in the annotation, ignores it — the mechanical witness of
+  T1). Every `print*` helper similarly gains `… a -> …` and ignores the slot.
+
+- Add a *second, real* backend to prove the seam (this is the deliverable that
+  makes the refactor checkable — §6): `src/AnnotDump.hs`, a debug backend that
+  pretty-prints the *annotated* tree (block/binding labels included), i.e. the
+  first consumer that actually reads `a`. It need not be pretty Haskell — its job
+  is to demonstrate (and test) that a backend *other than* the Haskell printer
+  can read the annotation the Haskell backend ignores. It doubles as a debugging
+  aid for 05.
+
+### 4.4 `app/Main.hs` — select a backend, thread the pass
+
+- New flag, e.g. `--backend haskell|annot-dump` (default `haskell`), parsed
+  alongside the existing `--graph-viz` / `--dominance-viz` modes.
+- Pipeline: `parse → translate → annotate → render chosenBackend`. Wire
+  `annotate` (§4.5) unconditionally (D4).
+
+### 4.5 New: `src/Effect.hs` — the (trivial) annotation pass
+
+- `data Effect = Pure deriving (Eq, Show)` with `Semigroup`/`Monoid` instances
+  realising `(⊔, ⊥)` (currently `Pure <> Pure = Pure`, `mempty = Pure`) so 05
+  inherits the lattice shape (§2.2).
+- `annotate :: Anf.Program () -> Anf.Program Effect`, currently `fmap (const
+  Pure)`. That one line is the whole pass today; 05 replaces its *body* with the
+  real bottom-up inference (using `foldMap` for the join), changing **no
+  signatures and no pipeline wiring** — the forward-compat contract (§7).
+
+### 4.6 `src/GraphViz.hs`, `src/Dominance.hs`
+
+- Untouched. They operate on `Ast`/the CFG, not on `Anf`.
+
+### 4.7 `package.yaml`
+
+- Register `Backend`, `Effect`, `AnnotDump` (and the new spec module). Edit
+  hpack, never the generated `.cabal` (per CLAUDE.md).
+
+---
+
+## 5. The non-negotiable invariant: identical output
+
+Because this is a refactor, the corpus is the oracle. After the change:
+
+- Every `examples/*.ll` still parses (`ExamplesSpec`).
+- The golden `.hs` under `docs/{gcd,prime,safe_div}` are **unchanged** — not
+  "regenerated," *unchanged*. If a single byte moves, the refactor altered
+  behaviour and is wrong (this is T1 made operational).
+- The differential harness (`test/differential/run.py`) still certifies the
+  whole corpus bit-for-bit against clang, with no change to the harness itself.
+
+If all three hold, T1/T2 hold on the corpus and the Haskell path is proven
+behaviour-preserving.
+
+---
+
+## 6. How this is checked — verifying a refactor with no visible feature
+
+The hard part of evaluating 04 is that "it works" looks identical to "it does
+nothing." The verification therefore targets the two theorems directly, plus the
+new seam:
+
+1. **T1, by golden diff (regression).** `stack test` + the unchanged
+   `docs/*` goldens + `git diff` showing zero change to generated `.hs`. This is
+   the primary gate.
+2. **T1, as a property test** (new `test/AnnotatedSpec.hs`): for every example,
+   `printProgram (annotate (translate ast)) == printProgram (translate ast)`
+   after erasure — i.e. relabelling the tree (`fmap (const Pure)` then anything)
+   does not change Haskell output. Encodes naturality, not just one corpus run.
+3. **T2, pipeline factorisation** (same spec): assert the new
+   `render Haskell ∘ annotate ∘ translate` equals the old `printProgram ∘
+   translate` on the corpus, so inserting the pass is provably inert on the
+   Haskell backend.
+4. **The seam is real, not theoretical** (same spec): the `AnnotDump` backend,
+   run on a sample program, **reads** the annotation the Haskell backend ignores
+   and emits *different* text from the Haskell backend for the *same* tree. A
+   second backend that demonstrably consumes `a` is the concrete proof that
+   "`PrintAnf` is one of several" is now true, and the executable evidence that
+   05/06 have a working landing pad.
+5. **Effect lattice laws** (same spec): `Semigroup`/`Monoid` associativity and
+   identity for `Effect`, so 05 builds on a lawful join-semilattice.
+6. **Build hygiene:** `stack build` warning-clean under the `-Wall` set
+   (`package.yaml`), including the `DeriveFunctor`/`DeriveFoldable` additions.
+
+Run targets: `stack test --test-arguments '--match "/annotated/"'`,
+`stack test --test-arguments '--match "parses all examples"'`,
+`python3 test/differential/run.py`.
+
+---
+
+## 7. How 05 and 06 drop in — the forward-compatibility contract
+
+The deliverable promise (mirroring the [09 plan §7](09-floating-point.md)) is
+that the two godmode items become *body* changes, not architecture changes:
+
+- **05 (effect inference)** replaces the body of `annotate` (§4.5) with the real
+  bottom-up analysis. It changes **no signatures, no pipeline wiring, no
+  backend**. It enriches `data Effect` beyond `Pure` and computes the join with
+  `foldMap`. The "every function is `Pure`" baseline is *already running and
+  tested* (§6.3/§6.5), so 05 starts from a green, wired pipeline and only has to
+  make the labels true. Its sanity milestone ("all pure") is literally the 04
+  default.
+- **06 (monadic translation)** adds one `instance Backend Monadic` in a new
+  module and selects it with `--backend monadic`. It reads the `Effect` label
+  (present since 04, meaningful since 05) to choose `do`/`>>=` vs `let … in` per
+  block. It changes **nothing** in `Anf`, `Translate`, `Effect`, or the Haskell
+  backend — the open/closed property from §2.3.
+
+That both items reduce to "swap one body" / "add one instance" is the test that
+04 drew the structural/derived and term/algebra boundaries correctly. If either
+needs to touch `Anf`'s structure or `Translate`, 04 mis-placed a boundary.
+
+---
+
+## 8. How the value reaches the *results* (the paper)
+
+04 produces no new translated programs, so its contribution to the dissertation
+is **conceptual scaffolding**, and it should be written up as such:
+
+- **A cleaner statement of `F`.** With the annotation parameter, the paper can
+  present the translation as producing a *decorated* ANF term and the printers as
+  *algebras* over it (§2.3), then state effect analysis as a comonadic relabel
+  (§2.1) and monadic emission as a second algebra (§2.4). This is the precise
+  vocabulary the Discussion section's "ANF ≡ Moggi's computational λ-calculus"
+  claim (cited in [06](../06-monadic-effects-translation.md)) needs to become a
+  construction rather than a remark.
+- **Two provable refactor theorems (T1/T2, §2.4)** give the paper a worked
+  example of *behaviour-preserving program transformation verified by golden +
+  property tests* — a small but honest methodological contribution, and the model
+  for how the riskier 05/06 changes will later be validated.
+- **The figure that pays off later.** A single diagram —
+  `Ast → translate → Anf() → annotate → Anf(Effect) → {Haskell | Monadic | …}` —
+  is the architecture the Future Work chapter already gestures at; landing 04
+  lets the paper draw it as *implemented*, with 05 and 06 shown as the two
+  pending bodies/instances rather than open-ended research.
+
+So the value is realised not as a corpus row but as: (a) the formal framing 05/06
+are stated in, (b) a verified-refactor methodology exemplar, and (c) a concrete
+architecture diagram. The honest framing in the paper is "this chapter builds the
+seam; the next two chapters fill it" — which matches the roadmap's "enabler, not
+valuable on its own."
+
+---
+
+## 9. Open decisions for the author
+
+1. **`Effect` location.** Ship the trivial `Effect`/`annotate` in 04 (recommended
+   — makes T2 testable now, D4), or leave the slot polymorphic and let 05
+   introduce `Effect` entirely? Shipping the trivial carrier costs ~3 lines and
+   buys a wired, green pipeline; recommended.
+2. **Second backend choice.** `AnnotDump` (debug, reads `a`) is the cheapest way
+   to *prove* the seam (§6.4). Alternatives that also prove it: a minimal C
+   backend, or an S-expression dump of the typed+annotated tree. Pick whichever
+   best serves the paper's figure; `AnnotDump` is enough for verification.
+3. **`recursion-schemes` / `Cofree`.** This plan deliberately avoids them (§2.1),
+   realising the same structure with `DeriveFunctor`/`DeriveFoldable` to match
+   the `Ast` idiom and keep the code readable for the TCC. Revisit only if 05's
+   analysis turns out to want generic recursion schemes — unlikely at this scope.
+4. **Granularity of the effect label.** Per-binding *and* per-block *and*
+   per-function (uniform, D1) vs. per-block only. Uniform is recommended; 05 can
+   ignore the finer labels if it only needs per-block, and the `Foldable` join
+   reconstructs coarser labels from finer ones for free.

--- a/llvm-ir-to-functional.cabal
+++ b/llvm-ir-to-functional.cabal
@@ -26,9 +26,12 @@ source-repository head
 library
   exposed-modules:
       Anf
+      AnnotDump
       Ast
       AstHelpers
+      Backend
       Dominance
+      Effect
       GraphViz
       Lexer
       NameNormalizer
@@ -80,6 +83,7 @@ test-suite llvm-ir-to-functional-test
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+      AnnotatedSpec
       BitWidthSpec
       BooleanSpec
       ExamplesSpec

--- a/src/Anf.hs
+++ b/src/Anf.hs
@@ -1,4 +1,28 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFoldable #-}
 
+-- | The output (functional / ANF) abstract syntax. Every node is parameterised
+-- over an /annotation/ type @a@, exactly as the input 'Ast.Program' is
+-- parameterised over a source 'Range'. The annotation is a slot for /derived/
+-- analysis results — an effect label, primarily (see "Effect") — that a pass
+-- writes onto an already-built tree and a backend may read.
+--
+-- Two kinds of decoration live on this tree, and they are deliberately kept
+-- apart (see docs/roadmap/plans/04-annotated-anf-ast.md §2.1):
+--
+--   * /Essential/ data — the 'Ty' fields — is part of a term's meaning and
+--     directs code generation; every backend consumes it. It is constructor
+--     data, not an annotation, and is present from construction.
+--   * /Derived/ data — the @a@ annotation — is computed by a pass after the
+--     term exists and is consumed by /some/ backends only. The base term built
+--     by "Translate" carries @()@; the "Effect" pass relabels it to @Effect@.
+--
+-- Because @a@ is the last type parameter and is threaded through every recursive
+-- position, the derived 'Functor' gives label rewriting (and, with
+-- @'fmap' (const ())@, label /erasure/) and the derived 'Foldable' gives label
+-- aggregation (@'foldMap'@ joins every label — used to roll a block's effect up
+-- from its bindings'). These two come for free precisely because of the uniform
+-- parameterisation; nothing hand-written traverses the tree.
 module Anf (
   Program(..),
   Function(..),
@@ -14,89 +38,102 @@ module Anf (
   Call(..),
   IfThenElse(..),
   Value(..),
+  erase,
 ) where
 
 import TypeSystem (Ty)
 
-newtype Program = Program [Function] deriving (Show, Eq)
+-- | Erase every annotation, recovering the bare term. By naturality this is the
+-- identity as far as any annotation-blind backend (e.g. the Haskell printer) is
+-- concerned: @render . erase = render@. See plan §2.4 (T1).
+erase :: Functor f => f a -> f ()
+erase = fmap (const ())
+
+newtype Program a = Program [Function a]
+  deriving (Show, Eq, Functor, Foldable)
 
 -- | A whole LLVM function. The @['Ty']@ are the argument types and the trailing
 -- 'Ty' is the return type; together they form the emitted top-level signature,
--- which anchors bit-width inference.
-data Function =
-  Function String [ArgumentDef] [Ty] Ty Lambda Call
-  deriving (Show, Eq)
+-- which anchors bit-width inference. The leading @a@ is the function-level
+-- annotation (e.g. its aggregate effect).
+data Function a =
+  Function a String [ArgumentDef a] [Ty] Ty (Lambda a) (Call a)
+  deriving (Show, Eq, Functor, Foldable)
 
-newtype ArgumentDef =
-  ArgumentDef String
-  deriving (Show, Eq)
+data ArgumentDef a =
+  ArgumentDef a String
+  deriving (Show, Eq, Functor, Foldable)
 
-data Lambda =
-  Lambda String [ArgumentDef] [Expr] [Lambda] Flow
-  deriving (Show, Eq)
+-- | A basic block, reconstructed as a lambda. The leading @a@ is the block-level
+-- annotation — the natural granularity for per-block purity in
+-- [effect inference](docs/roadmap/05-effect-inference.md).
+data Lambda a =
+  Lambda a String [ArgumentDef a] [Expr a] [Lambda a] (Flow a)
+  deriving (Show, Eq, Functor, Foldable)
 
-newtype Expr
-  = ExpDecl Decl
-  -- | ExpCall Call
-  deriving (Show, Eq)
+newtype Expr a
+  = ExpDecl (Decl a)
+  -- | ExpCall (Call a)
+  deriving (Show, Eq, Functor, Foldable)
 
 -- | Each binding carries the 'Ty' of its result so the printer can annotate it
--- and pin the representation. 'DeclConvOp' is the exception: the conversion
--- already names its target type, so it needs no separate annotation.
-data Decl
-  = DeclBinOp String Ty BinOp
-  | DeclCall String Ty Call
-  | DeclIcmp String Ty Icmp
-  | DeclSelect String Ty Select
-  | DeclConvOp String ConvOp
+-- and pin the representation, and the leading @a@ for its derived label — the
+-- finest effect granularity. 'DeclConvOp' has no result-'Ty' field because the
+-- conversion already names its target type.
+data Decl a
+  = DeclBinOp a String Ty (BinOp a)
+  | DeclCall a String Ty (Call a)
+  | DeclIcmp a String Ty (Icmp a)
+  | DeclSelect a String Ty (Select a)
+  | DeclConvOp a String (ConvOp a)
   -- | An LLVM @freeze@: a typed alias binding @name = value@ (freeze is the
   -- identity in the pure subset). The 'Ty' is the result type annotation.
-  | DeclFreeze String Ty Value
-  deriving (Show, Eq)
+  | DeclFreeze a String Ty (Value a)
+  deriving (Show, Eq, Functor, Foldable)
 
 -- | A conversion: the LLVM op name (@trunc@\/@zext@\/@sext@\/@sitofp@\/…), the
 -- source and target 'Ty' (conversions may cross sorts, so widths alone are
 -- insufficient), and the value being converted.
-data ConvOp
-  = ConvOp String Ty Ty Value
-  deriving (Show, Eq)
+data ConvOp a
+  = ConvOp a String Ty Ty (Value a)
+  deriving (Show, Eq, Functor, Foldable)
 
-data Select
-  = Select Value Value Value
-  deriving (Show, Eq)
+data Select a
+  = Select a (Value a) (Value a) (Value a)
+  deriving (Show, Eq, Functor, Foldable)
 
 -- | A comparison: the predicate, the /operand/ 'Ty' (so the printer can pick
 -- NaN-faithful codegen for floating @fcmp@ vs a plain operator for integer
 -- @icmp@), and the two operands. The result is always an i1.
-data Icmp
-  = Icmp String Ty Value Value
-  deriving (Show, Eq)
+data Icmp a
+  = Icmp a String Ty (Value a) (Value a)
+  deriving (Show, Eq, Functor, Foldable)
 
-data Flow
-  = FlowCall Call
-  | FlowCond IfThenElse
-  deriving (Show, Eq)
+data Flow a
+  = FlowCall (Call a)
+  | FlowCond (IfThenElse a)
+  deriving (Show, Eq, Functor, Foldable)
 
-data BinOp
-  = BinOp String Value Value
-  deriving (Show, Eq)
+data BinOp a
+  = BinOp a String (Value a) (Value a)
+  deriving (Show, Eq, Functor, Foldable)
 
-data Call
-  = Call Value [Value]
-  deriving (Show, Eq)
+data Call a
+  = Call a (Value a) [Value a]
+  deriving (Show, Eq, Functor, Foldable)
 
-data IfThenElse
-  = IfThenElse Value Call Call
-  deriving (Show, Eq)
+data IfThenElse a
+  = IfThenElse a (Value a) (Call a) (Call a)
+  deriving (Show, Eq, Functor, Foldable)
 
-data Value
-  = Const Integer
+data Value a
+  = Const a Integer
   -- | A floating constant: the (Haskell-renderable) literal text and its 'Ty'
   -- (so the printer emits @Float@ vs @Double@ and an explicitly-typed literal).
-  | FConst String Ty
+  | FConst a String Ty
   -- | A boolean constant, from an @i1@ literal (LLVM @true@\/@false@). Printed
   -- bare as @True@\/@False@.
-  | BConst Bool
-  | Name String
-  | Unit
-  deriving (Show, Eq)
+  | BConst a Bool
+  | Name a String
+  | Unit a
+  deriving (Show, Eq, Functor, Foldable)

--- a/src/AnnotDump.hs
+++ b/src/AnnotDump.hs
@@ -1,0 +1,77 @@
+-- | A debugging backend that dumps the /annotated/ ANF tree, effect labels
+-- included. It exists to demonstrate — and let the test-suite assert — that a
+-- backend other than the Haskell printer can read the annotation the Haskell
+-- printer ignores. It is the concrete witness that "PrintAnf is one of several
+-- backends" is now true (docs/roadmap/plans/04-annotated-anf-ast.md §6), and it
+-- doubles as an inspection aid for [item 05](docs/roadmap/05-effect-inference.md)
+-- once effect inference makes the labels non-trivial.
+--
+-- The renderer is polymorphic over any 'Show'-able annotation, so it works on
+-- the @()@ tree straight out of "Translate" as well as the @Effect@ tree out of
+-- "Effect.annotate"; the backend value is the @Effect@ instantiation.
+module AnnotDump
+  ( dumpProgram
+  , annotDumpBackend
+  ) where
+
+import Anf
+import Backend (Backend(..))
+import TypeSystem (rho)
+
+import Data.List (intercalate)
+
+-- | The Effect-annotated backend value selectable as @annot-dump@.
+annotDumpBackend :: Backend
+annotDumpBackend = Backend { backendName = "annot-dump", render = dumpProgram }
+
+-- | Render the annotation-bearing structure of a program. Unlike the Haskell
+-- backend this is not executable code; it surfaces every node's label.
+dumpProgram :: Show a => Program a -> String
+dumpProgram (Program fs) = intercalate "\n" (map dumpFunction fs)
+
+dumpFunction :: Show a => Function a -> String
+dumpFunction (Function ann name _ argTypes retType lambda _) =
+  line 0 ("function " ++ name ++ " :: "
+            ++ intercalate " -> " (map rho (argTypes ++ [retType]))
+            ++ "    -- effect: " ++ show ann)
+    ++ dumpLambda 1 lambda
+
+dumpLambda :: Show a => Int -> Lambda a -> String
+dumpLambda d (Lambda ann name _ exprs nested flow) =
+  line d ("block " ++ name ++ "    -- effect: " ++ show ann)
+    ++ concatMap (dumpExpr (d + 1)) exprs
+    ++ concatMap (dumpLambda (d + 1)) nested
+    ++ line (d + 1) ("flow: " ++ dumpFlow flow)
+
+dumpExpr :: Show a => Int -> Expr a -> String
+dumpExpr d (ExpDecl decl) = dumpDecl d decl
+
+dumpDecl :: Show a => Int -> Decl a -> String
+dumpDecl d decl = line d (kindAnn decl)
+  where
+    kindAnn x = describe x ++ "    -- effect: " ++ show (declAnn x)
+
+-- | The label hung on a binding.
+declAnn :: Decl a -> a
+declAnn (DeclBinOp ann _ _ _) = ann
+declAnn (DeclCall ann _ _ _)  = ann
+declAnn (DeclIcmp ann _ _ _)  = ann
+declAnn (DeclSelect ann _ _ _) = ann
+declAnn (DeclConvOp ann _ _)  = ann
+declAnn (DeclFreeze ann _ _ _) = ann
+
+-- | A one-line summary of a binding (name and kind), label-free.
+describe :: Decl a -> String
+describe (DeclBinOp _ n ty _)  = n ++ " = binop :: " ++ rho ty
+describe (DeclCall _ n ty _)   = n ++ " = call :: " ++ rho ty
+describe (DeclIcmp _ n ty _)   = n ++ " = icmp :: " ++ rho ty
+describe (DeclSelect _ n ty _) = n ++ " = select :: " ++ rho ty
+describe (DeclConvOp _ n _)    = n ++ " = convop"
+describe (DeclFreeze _ n ty _) = n ++ " = freeze :: " ++ rho ty
+
+dumpFlow :: Flow a -> String
+dumpFlow (FlowCall _) = "tail-call"
+dumpFlow (FlowCond _) = "if/then/else"
+
+line :: Int -> String -> String
+line d s = replicate (d * 2) ' ' ++ s ++ "\n"

--- a/src/AnnotDump.hs
+++ b/src/AnnotDump.hs
@@ -25,7 +25,11 @@ annotDumpBackend :: Backend
 annotDumpBackend = Backend { backendName = "annot-dump", render = dumpProgram }
 
 -- | Render the annotation-bearing structure of a program. Unlike the Haskell
--- backend this is not executable code; it surfaces every node's label.
+-- backend this is not executable code; it surfaces the label on each /function/,
+-- /block/ and /binding/ — the three granularities effect inference works at
+-- (per-function, per-block, per-binding; see plan §3 D1 / open decision 4). Leaf
+-- operand nodes ('Value', 'BinOp', 'Call', …) also carry a label, but it is the
+-- inert unit\/⊥ and conveys nothing, so it is intentionally not shown.
 dumpProgram :: Show a => Program a -> String
 dumpProgram (Program fs) = intercalate "\n" (map dumpFunction fs)
 

--- a/src/Backend.hs
+++ b/src/Backend.hs
@@ -1,0 +1,50 @@
+-- | The output-backend interface. A backend is a way of rendering an analysed
+-- 'Anf.Program' to text; the translator and the effect pass are fixed, and the
+-- backend is the interchangeable last stage.
+--
+-- Formally each backend is an /algebra/ over the ANF term: a structurally
+-- recursive map @μA → String@. The Haskell printer ("PrintAnf") is one such
+-- algebra (its hand-written recursion /is/ the fold); the monadic printer of
+-- [item 06](docs/roadmap/06-monadic-effects-translation.md) will be another over
+-- the same term. Adding a backend never touches the term or the other
+-- backends — the open/closed property this seam buys. See
+-- docs/roadmap/plans/04-annotated-anf-ast.md §2.3.
+--
+-- A backend is represented as a /record of functions/ rather than a type class
+-- so that the set of available backends is an ordinary, heterogeneous value
+-- ('backends'-style menus, selection by name) with no existential machinery.
+--
+-- Every backend receives the /annotated/ tree ('Anf.Program' 'Effect') so the
+-- pipeline is single and uniform. An annotation-blind backend (the Haskell one)
+-- simply ignores the labels; an annotation-aware backend (the monadic one, or
+-- the debugging 'AnnotDump') reads them.
+module Backend
+  ( Backend(..)
+  , runBackend
+  , lookupBackend
+  ) where
+
+import qualified Anf
+import Effect (Effect)
+
+-- | A renderable output target: a name to select it by, and the rendering
+-- algebra itself.
+data Backend = Backend
+  { backendName :: String
+  , render      :: Anf.Program Effect -> String
+  }
+
+-- | Render with the backend identified by @name@, drawn from a menu. Returns
+-- 'Left' with the offending name if it is unknown.
+runBackend :: [Backend] -> String -> Anf.Program Effect -> Either String String
+runBackend backends name prog =
+  case lookupBackend backends name of
+    Just b  -> Right (render b prog)
+    Nothing -> Left name
+
+-- | Find a backend by its 'backendName'.
+lookupBackend :: [Backend] -> String -> Maybe Backend
+lookupBackend backends name =
+  case filter ((== name) . backendName) backends of
+    (b:_) -> Just b
+    []    -> Nothing

--- a/src/Effect.hs
+++ b/src/Effect.hs
@@ -1,0 +1,46 @@
+-- | The annotation payload carried by an analysed 'Anf.Program', and the
+-- (currently trivial) pass that computes it.
+--
+-- Effects form a bounded join-semilattice @(E, ⊔, ⊋)@: @⊋ = 'Pure'@ is the
+-- bottom (no effect), and the join @e₁ ⊔ e₂@ is "exhibits both effects." The
+-- 'Semigroup'\/'Monoid' instances realise @(⊔, ⊥)@ so that a coarser label can
+-- be rolled up from finer ones with 'foldMap' — a block's effect is the join of
+-- its bindings', a function's the join of its blocks' — straight off the
+-- 'Foldable' instance of "Anf".
+--
+-- The accepted LLVM-IR subset is pure by construction, so the only inhabited
+-- point today is 'Pure' and 'annotate' labels every node with it. That is the
+-- sanity baseline of [effect inference](docs/roadmap/05-effect-inference.md):
+-- every function /must/ infer effect-free. Item 05 replaces the /body/ of
+-- 'annotate' (and enriches 'Effect') without changing any signature or the
+-- pipeline; see docs/roadmap/plans/04-annotated-anf-ast.md §7.
+module Effect
+  ( Effect(..)
+  , annotate
+  ) where
+
+import qualified Anf
+
+-- | The effect lattice. Only 'Pure' is reachable in the current pure subset;
+-- item 05 adds the inhabited points (e.g. a call to an unknown declared
+-- function, or a trapping division).
+data Effect
+  = Pure  -- ^ The bottom @⊋@: no observable effect.
+  deriving (Eq, Show)
+
+-- | Join @(⊔)@. With only 'Pure' present it is constant, but the law structure
+-- is what item 05 builds on, so it is stated now.
+instance Semigroup Effect where
+  Pure <> Pure = Pure
+
+-- | Identity element @⊋ = 'Pure'@.
+instance Monoid Effect where
+  mempty = Pure
+
+-- | Decorate a freshly-translated term with effect labels. Today this is the
+-- constant-'Pure' relabelling (the pure baseline); item 05 swaps in the real
+-- bottom-up inference here. Running it unconditionally — even while trivial —
+-- is what keeps the rest of the pipeline (and the backends) stable across that
+-- change (plan §3 D4).
+annotate :: Anf.Program () -> Anf.Program Effect
+annotate = fmap (const Pure)

--- a/src/PrintAnf.hs
+++ b/src/PrintAnf.hs
@@ -1,14 +1,21 @@
-{-# LANGUAGE GADTs #-}
-
-module PrintAnf (printProgram) where
+module PrintAnf (printProgram, haskellBackend) where
 
 import Data.List (intercalate)
 
 import Anf
+import Backend (Backend(..))
 import TranslateAux
 import TypeSystem (Ty(..), rho, widthOf, isFloating)
 
 import Text.Printf (printf)
+
+-- | The Haskell source backend. It is /annotation-blind/: 'printProgram' is
+-- parameterised over the annotation type and never inspects it, so by naturality
+-- (plan §2.4, T1) it renders an annotated tree exactly as it renders the bare
+-- one. Hence the same printer serves @'Anf.Program' 'Effect'@ here and the
+-- @'Anf.Program' ()@ produced straight out of "Translate" in tests.
+haskellBackend :: Backend
+haskellBackend = Backend { backendName = "haskell", render = printProgram }
 
 header :: String
 header = "import Data.Bits\n\
@@ -16,23 +23,23 @@ header = "import Data.Bits\n\
          \import Data.Word\n\
          \import GHC.Float (float2Double, double2Float)\n\n"
 
-printProgram :: Program -> String
+printProgram :: Program a -> String
 printProgram (Program functions) = header ++ intercalate "\n\n" (map printFunction functions)
 
-printFunction :: Function -> String
-printFunction (Function name args argTypes retType lambda call) =
+printFunction :: Function a -> String
+printFunction (Function _ name args argTypes retType lambda call) =
   let
     functionArgs = unrollArguments args
     firstBlockLabel = printCall call
     signature = signatureString name (intercalate " -> " (map rho (argTypes ++ [retType])))
   in signature ++ functionString name functionArgs (printLet lambda 2) firstBlockLabel
 
-unrollArguments :: [ArgumentDef] -> String
-unrollArguments ((ArgumentDef name):x) = name ++ " " ++ unrollArguments x
+unrollArguments :: [ArgumentDef a] -> String
+unrollArguments ((ArgumentDef _ name):x) = name ++ " " ++ unrollArguments x
 unrollArguments [] = ""
 
-printLet :: Lambda -> Int -> String
-printLet (Lambda name args exprs lets flow) level =
+printLet :: Lambda a -> Int -> String
+printLet (Lambda _ name args exprs lets flow) level =
   let
     lambdaArgs = unrollArguments args
     bindings = concatMap (`printExpr` (level + 2)) exprs
@@ -40,26 +47,26 @@ printLet (Lambda name args exprs lets flow) level =
     tailCall = printTailCall flow (level + 1)
   in blockString level name lambdaArgs bindings nestedLambdas tailCall
 
-printExpr :: Expr -> Int -> String
+printExpr :: Expr a -> Int -> String
 printExpr (ExpDecl decl) l = indent l $ printDecl decl
 -- printExpr (ExpCall call) l = indent l $ printCall call
 
-printCall :: Call -> String
-printCall (Call (Name fname) values) = fname ++ " " ++ unwords (map printValue values)
-printCall (Call (Const value) _) = show value
-printCall (Call c@(FConst _ _) _) = printValue c
-printCall (Call c@(BConst _) _) = printValue c
-printCall (Call Unit _) = "()"
+printCall :: Call a -> String
+printCall (Call _ (Name _ fname) values) = fname ++ " " ++ unwords (map printValue values)
+printCall (Call _ (Const _ value) _) = show value
+printCall (Call _ c@(FConst {}) _) = printValue c
+printCall (Call _ c@(BConst _ _) _) = printValue c
+printCall (Call _ (Unit _) _) = "()"
 
-printDecl :: Decl -> String
-printDecl (DeclBinOp name ty binop) = declString name (annot (printBinOp ty binop) ty)
-printDecl (DeclCall name ty call) = declString name (annot (printCall call) ty)
-printDecl (DeclIcmp name ty icmp) = declString name (annot (printIcmp icmp) ty)
-printDecl (DeclSelect name ty select) = declString name (annot (printSelect select) ty)
+printDecl :: Decl a -> String
+printDecl (DeclBinOp _ name ty binop) = declString name (annot (printBinOp ty binop) ty)
+printDecl (DeclCall _ name ty call) = declString name (annot (printCall call) ty)
+printDecl (DeclIcmp _ name ty icmp) = declString name (annot (printIcmp icmp) ty)
+printDecl (DeclSelect _ name ty select) = declString name (annot (printSelect select) ty)
 -- A conv op already names its target type, so it is not wrapped again.
-printDecl (DeclConvOp name convop) = declString name (printConvOp convop)
+printDecl (DeclConvOp _ name convop) = declString name (printConvOp convop)
 -- freeze is the identity: emit a typed alias @name = (value) :: IntN@.
-printDecl (DeclFreeze name ty value) = declString name (annot (printValue value) ty)
+printDecl (DeclFreeze _ name ty value) = declString name (annot (printValue value) ty)
 
 -- | Pin a binding's result type: @(expr) :: Int32@.
 annot :: String -> Ty -> String
@@ -68,8 +75,8 @@ annot expr ty = printf "(%s) :: %s" expr (rho ty)
 -- An @icmp@\/@fcmp@ result is a 'Bool' (its 'DeclIcmp' 'Ty' is 'TyBool', so the
 -- enclosing 'annot' pins @:: Bool@); emit the bare comparison and let the branch
 -- / select / return that consumes it use it directly.
-printIcmp :: Icmp -> String
-printIcmp (Icmp cmp ty a b) = cmpExpr ty cmp (printValue a) (printValue b)
+printIcmp :: Icmp a -> String
+printIcmp (Icmp _ cmp ty a b) = cmpExpr ty cmp (printValue a) (printValue b)
 
 -- | The Haskell boolean expression for a comparison predicate.
 --
@@ -98,18 +105,18 @@ cmpExpr ty cmp a b
     unordered op = printf "isNaN %s || isNaN %s || %s %s %s" a b a op b
 
 -- The select condition is an i1 ('Bool'), so it drives @if@ directly.
-printSelect :: Select -> String
-printSelect (Select a b c) = printf "if %s then %s else %s" (printValue a) (printValue b) (printValue c)
+printSelect :: Select a -> String
+printSelect (Select _ a b c) = printf "if %s then %s else %s" (printValue a) (printValue b) (printValue c)
 
-printConvOp :: ConvOp -> String
+printConvOp :: ConvOp a -> String
 -- An i1 ('Bool') source: clang's @zext i1@\/@sext i1@ reintroduce the integer
 -- 0/1 (or 0/-1 for sext) that a comparison result is widened back into. This is
 -- the Bool->int boundary coercion; widths play no role, so it precedes the
 -- width-driven cases below.
-printConvOp (ConvOp op TyBool tgt value) =
+printConvOp (ConvOp _ op TyBool tgt value) =
   printf "(if %s then %s else 0) :: %s" (printValue value) trueVal (rho tgt)
   where trueVal = if op == "sext" then "(-1)" else "1" :: String
-printConvOp (ConvOp op src tgt value) = case op of
+printConvOp (ConvOp _ op src tgt value) = case op of
   -- zext / uitofp zero-extend the source: round-trip through its unsigned word
   -- type first, so the sign bit is not propagated.
   "zext"    -> printf "fromIntegral (fromIntegral %s :: %s) :: %s" v (wordOf src) tgtTy
@@ -131,10 +138,10 @@ printConvOp (ConvOp op src tgt value) = case op of
 -- The 'Ty' selects the boolean reading of @and@\/@or@\/@xor@ on i1 operands:
 -- on 'TyBool' they are the logical connectives (@&&@\/@||@\/@\/=@), not the
 -- 'Data.Bits' word operators their integer counterparts use.
-printBinOp :: Ty -> BinOp -> String
-printBinOp TyBool (BinOp op left right)
+printBinOp :: Ty -> BinOp a -> String
+printBinOp TyBool (BinOp _ op left right)
   | op `elem` ["and", "or", "xor"] = printValue left ++ boolOperator op ++ printValue right
-printBinOp _ (BinOp op left right) = printValue left ++ translateOperator op ++ rhs
+printBinOp _ (BinOp _ op left right) = printValue left ++ translateOperator op ++ rhs
   where
     -- Haskell's shift functions take the amount as `Int`, but LLVM types both
     -- shift operands at the same iN, so the (sized) amount needs coercing.
@@ -150,21 +157,21 @@ boolOperator "or"  = " || "
 boolOperator "xor" = " /= "
 boolOperator op    = error ("boolOperator: not a boolean op: " ++ op)
 
-printValue :: Value -> String
-printValue (Const c) = if c < 0 then "(" ++ show c ++ ")" else show c
+printValue :: Value a -> String
+printValue (Const _ c) = if c < 0 then "(" ++ show c ++ ")" else show c
 -- A floating literal is always parenthesised and explicitly typed, so it is
 -- unambiguous as an operand/argument and pins Float vs Double (no defaulting).
-printValue (FConst txt ty) = printf "(%s :: %s)" txt (rho ty)
-printValue (BConst b) = if b then "True" else "False"
-printValue (Name n) = n
-printValue Unit = "()"
+printValue (FConst _ txt ty) = printf "(%s :: %s)" txt (rho ty)
+printValue (BConst _ b) = if b then "True" else "False"
+printValue (Name _ n) = n
+printValue (Unit _) = "()"
 
-printTailCall :: Flow -> Int -> String
+printTailCall :: Flow a -> Int -> String
 printTailCall (FlowCall call) l = indent l "in " ++ printCall call ++ "\n"
 printTailCall (FlowCond cond) l = printCond cond l
 
-printCond :: IfThenElse -> Int -> String
-printCond (IfThenElse cond thenCall elseCall) l = condString l (printValue cond) (printCall thenCall) (printCall elseCall)
+printCond :: IfThenElse a -> Int -> String
+printCond (IfThenElse _ cond thenCall elseCall) l = condString l (printValue cond) (printCall thenCall) (printCall elseCall)
 
 signatureString :: String -> String -> String
 signatureString = printf "%s :: %s\n"

--- a/src/Translate.hs
+++ b/src/Translate.hs
@@ -17,22 +17,27 @@ import AstHelpers
 
 import Dominance (buildGraph, dominance)
 
-translate :: Ast.Program Range -> Anf.Program
+-- | Translation produces the /unlabelled/ term @'Anf.Program' ()@. Derived
+-- annotations (effects) are written by a separate pass ("Effect.annotate") that
+-- runs after translation; keeping the two stages apart is the point of
+-- docs/roadmap/plans/04-annotated-anf-ast.md. Every node is built with the unit
+-- annotation @()@.
+translate :: Ast.Program Range -> Anf.Program ()
 translate (Ast.Program fs) = Anf.Program $ map translateFunction fs
 
-translateFunction :: Ast.Function Range -> Anf.Function
+translateFunction :: Ast.Function Range -> Anf.Function ()
 translateFunction function = buildAnfFromFunction function dom
   where
     g = buildGraph function
     dom = dominance g
 
-buildAnfFromFunction :: Ast.Function Range -> Gr String () -> Anf.Function
+buildAnfFromFunction :: Ast.Function Range -> Gr String () -> Anf.Function ()
 buildAnfFromFunction (Ast.FunctionDef _ retTy name args blocks) dom =
-  Anf.Function (nameToString name) (anfArgs args) (argTypes args) (typeStr retTy) lambda callFirstBlock
+  Anf.Function () (nameToString name) (anfArgs args) (argTypes args) (typeStr retTy) lambda callFirstBlock
   where
     lambda = anfFromTree blocks dom 0
     firstBlockLabel = firstBlockName blocks
-    callFirstBlock = Anf.Call (Anf.Name firstBlockLabel) []
+    callFirstBlock = Anf.Call () (Anf.Name () firstBlockLabel) []
 -- buildAnfFromFunction _ _ = undefined
 
 -- | Elaborate an LLVM type annotation into the internal 'Ty'.
@@ -48,7 +53,7 @@ argTypes as = map (\(Ast.ArgumentDef _ t _) -> typeStr t) as
 firstBlockName :: [Ast.BasicBlock Range] -> String
 firstBlockName = getLabel . head
 
-anfFromTree :: [Ast.BasicBlock Range] -> Gr String () -> Node -> Anf.Lambda
+anfFromTree :: [Ast.BasicBlock Range] -> Gr String () -> Node -> Anf.Lambda ()
 anfFromTree blocks gr node =
   let
     label = fromJust (lab gr node)
@@ -56,117 +61,117 @@ anfFromTree blocks gr node =
     children = suc gr node
     nestedLambdas = map (anfFromTree blocks gr) children
 
-    translateBlock :: Ast.BasicBlock Range -> [Anf.Lambda] -> Anf.Lambda
+    translateBlock :: Ast.BasicBlock Range -> [Anf.Lambda ()] -> Anf.Lambda ()
     translateBlock (Ast.BasicBlock _ _ phis stmts flow) nested =
       let
         args = argsFromPhis phis
         blockBindings = anfBindings stmts
         tailCall = tailCallFromBlock blocks label flow
-      in Anf.Lambda label args blockBindings nested tailCall
+      in Anf.Lambda () label args blockBindings nested tailCall
 
   in translateBlock block nestedLambdas
 
-anfArgs :: [Ast.ArgumentDef Range] -> [Anf.ArgumentDef]
-anfArgs [] = [Anf.ArgumentDef "()"]
+anfArgs :: [Ast.ArgumentDef Range] -> [Anf.ArgumentDef ()]
+anfArgs [] = [Anf.ArgumentDef () "()"]
 anfArgs args =
   let
-    anfArg :: Ast.ArgumentDef Range -> Anf.ArgumentDef
-    anfArg (Ast.ArgumentDef _ _ (Just name)) = Anf.ArgumentDef (nameToString name)
-    anfArg (Ast.ArgumentDef _ _ Nothing) = Anf.ArgumentDef "noname"
+    anfArg :: Ast.ArgumentDef Range -> Anf.ArgumentDef ()
+    anfArg (Ast.ArgumentDef _ _ (Just name)) = Anf.ArgumentDef () (nameToString name)
+    anfArg (Ast.ArgumentDef _ _ Nothing) = Anf.ArgumentDef () "noname"
   in map anfArg args
 
-argsFromPhis :: [Ast.PhiDec Range] -> [Anf.ArgumentDef]
-argsFromPhis [] = [Anf.ArgumentDef "()"]
+argsFromPhis :: [Ast.PhiDec Range] -> [Anf.ArgumentDef ()]
+argsFromPhis [] = [Anf.ArgumentDef () "()"]
 argsFromPhis phis =
   let
-    argFromPhi :: Ast.PhiDec Range -> Anf.ArgumentDef
-    argFromPhi (Ast.PhiDec _ name _) = Anf.ArgumentDef (nameToString name)
+    argFromPhi :: Ast.PhiDec Range -> Anf.ArgumentDef ()
+    argFromPhi (Ast.PhiDec _ name _) = Anf.ArgumentDef () (nameToString name)
   in map argFromPhi phis
 
-tailCallFromBlock :: [Ast.BasicBlock Range] -> String -> Ast.Flow Range -> Anf.Flow
+tailCallFromBlock :: [Ast.BasicBlock Range] -> String -> Ast.Flow Range -> Anf.Flow ()
 tailCallFromBlock _ _ (Ast.FlowReturn ret) = Anf.FlowCall (anfReturn ret)
 tailCallFromBlock blocks currentLabel (Ast.FlowBranch branch) = anfBranch blocks currentLabel branch
 
-anfBranch :: [Ast.BasicBlock Range] -> String -> Ast.Br Range -> Anf.Flow
+anfBranch :: [Ast.BasicBlock Range] -> String -> Ast.Br Range -> Anf.Flow ()
 anfBranch blocks currentLabel (Ast.Br _ [goto]) =
   let
     call = callFromGoto blocks currentLabel goto
   in Anf.FlowCall call
-anfBranch blocks currentLabel (Ast.Br _ (cond:gotoIf:gotoElse:_)) = 
+anfBranch blocks currentLabel (Ast.Br _ (cond:gotoIf:gotoElse:_)) =
   let
     condValue = valueFromName cond
 
     callIf = callFromGoto blocks currentLabel gotoIf
     callElse = callFromGoto blocks currentLabel gotoElse
-  in Anf.FlowCond $ Anf.IfThenElse condValue callIf callElse
+  in Anf.FlowCond $ Anf.IfThenElse () condValue callIf callElse
 anfBranch _ _ _ = undefined
 
-callFromGoto :: [Ast.BasicBlock Range] -> String -> Ast.Name Range -> Anf.Call
+callFromGoto :: [Ast.BasicBlock Range] -> String -> Ast.Name Range -> Anf.Call ()
 callFromGoto blocks currentLabel gotoLabel =
   let
     gotoName = nameToString gotoLabel
     block = findBlock blocks gotoName
-    anfName = Anf.Name gotoName
+    anfName = Anf.Name () gotoName
     anfArgsCall = callArgsFromBlockPhis block currentLabel
-  in Anf.Call anfName anfArgsCall
+  in Anf.Call () anfName anfArgsCall
 
-callArgsFromBlockPhis :: Ast.BasicBlock Range -> String -> [Anf.Value]
-callArgsFromBlockPhis (Ast.BasicBlock _ _ [] _ _) _ = [Anf.Unit]
+callArgsFromBlockPhis :: Ast.BasicBlock Range -> String -> [Anf.Value ()]
+callArgsFromBlockPhis (Ast.BasicBlock _ _ [] _ _) _ = [Anf.Unit ()]
 callArgsFromBlockPhis (Ast.BasicBlock _ _ phis _ _) label = map (callArgFromPhi label) phis
 
-callArgFromPhi :: String -> Ast.PhiDec Range -> Anf.Value
+callArgFromPhi :: String -> Ast.PhiDec Range -> Anf.Value ()
 callArgFromPhi currentLabel (Ast.PhiDec _ _ (Ast.Phi _ ty values)) = getValueForCurrentLabel (typeStr ty) values currentLabel
 
 -- | Resolve a φ-incoming value for the source block, typed by the φ-node's
 -- declared type (so a floating literal is tagged 'Anf.FConst' correctly).
-getValueForCurrentLabel :: Ty -> [(Ast.Value Range, Ast.Name Range)] -> String -> Anf.Value
+getValueForCurrentLabel :: Ty -> [(Ast.Value Range, Ast.Name Range)] -> String -> Anf.Value ()
 getValueForCurrentLabel ty values currentLabel =
   case filter (\(_, name) -> nameToString name == currentLabel) values of
     [(value, _)] -> anfValue ty value
     _ -> error $ "Phi value not found for label " ++ currentLabel
 
-anfReturn :: Ast.Return Range -> Anf.Call
-anfReturn (Ast.Return _ ty (Just valueReturned)) = Anf.Call (anfValue (typeStr ty) valueReturned) []
-anfReturn (Ast.Return _ _ Nothing) = Anf.Call Anf.Unit []
+anfReturn :: Ast.Return Range -> Anf.Call ()
+anfReturn (Ast.Return _ ty (Just valueReturned)) = Anf.Call () (anfValue (typeStr ty) valueReturned) []
+anfReturn (Ast.Return _ _ Nothing) = Anf.Call () (Anf.Unit ()) []
 
-anfBindings :: [Ast.Stmt Range] -> [Anf.Expr]
+anfBindings :: [Ast.Stmt Range] -> [Anf.Expr ()]
 anfBindings = map anfExpr
 
-anfExpr :: Ast.Stmt Range -> Anf.Expr
+anfExpr :: Ast.Stmt Range -> Anf.Expr ()
 anfExpr (Ast.SDec stmt) = Anf.ExpDecl (anfDec stmt)
 -- anfExpr (Ast.SCall stmt) = Anf.ExpCall (anfCall stmt)
 
-anfDec :: Ast.Dec Range -> Anf.Decl
-anfDec (Ast.DecCall _ name call@(Ast.Call _ ty _ _)) = Anf.DeclCall (nameToString name) (typeStr ty) (anfCall call)
-anfDec (Ast.DecBinOp _ name binop@(Ast.BinOpCall _ _ ty _ _)) = Anf.DeclBinOp (nameToString name) (typeStr ty) (anfBinOp binop)
-anfDec (Ast.DecConvOp _ name convop) = Anf.DeclConvOp (nameToString name) (anfConvOp convop)
+anfDec :: Ast.Dec Range -> Anf.Decl ()
+anfDec (Ast.DecCall _ name call@(Ast.Call _ ty _ _)) = Anf.DeclCall () (nameToString name) (typeStr ty) (anfCall call)
+anfDec (Ast.DecBinOp _ name binop@(Ast.BinOpCall _ _ ty _ _)) = Anf.DeclBinOp () (nameToString name) (typeStr ty) (anfBinOp binop)
+anfDec (Ast.DecConvOp _ name convop) = Anf.DeclConvOp () (nameToString name) (anfConvOp convop)
 -- icmp/fcmp always yield an i1 (= 'TyBool'), regardless of their (operand) type.
-anfDec (Ast.DecIcmp _ name icmp) = Anf.DeclIcmp (nameToString name) TyBool (anfIcmp icmp)
-anfDec (Ast.DecSelect _ name select@(Ast.Select _ ty _ _ _)) = Anf.DeclSelect (nameToString name) (typeStr ty) (anfSelect (typeStr ty) select)
-anfDec (Ast.DecFreeze _ name (Ast.Freeze _ ty value)) = Anf.DeclFreeze (nameToString name) (typeStr ty) (anfValue (typeStr ty) value)
+anfDec (Ast.DecIcmp _ name icmp) = Anf.DeclIcmp () (nameToString name) TyBool (anfIcmp icmp)
+anfDec (Ast.DecSelect _ name select@(Ast.Select _ ty _ _ _)) = Anf.DeclSelect () (nameToString name) (typeStr ty) (anfSelect (typeStr ty) select)
+anfDec (Ast.DecFreeze _ name (Ast.Freeze _ ty value)) = Anf.DeclFreeze () (nameToString name) (typeStr ty) (anfValue (typeStr ty) value)
 
-anfConvOp :: Ast.ConvOpCall Range -> Anf.ConvOp
+anfConvOp :: Ast.ConvOpCall Range -> Anf.ConvOp ()
 anfConvOp (Ast.ConvOpCall _ (Ast.ConvOp _ op) srcT value tgtT) =
-  Anf.ConvOp op (typeStr srcT) (typeStr tgtT) (anfValue (typeStr srcT) value)
+  Anf.ConvOp () op (typeStr srcT) (typeStr tgtT) (anfValue (typeStr srcT) value)
 
 -- | The select condition is an i1 (typed 'TyBool'); both arms carry the
 -- result type @ty@.
-anfSelect :: Ty -> Ast.Select Range -> Anf.Select
+anfSelect :: Ty -> Ast.Select Range -> Anf.Select ()
 anfSelect ty (Ast.Select _ _ condValue value1 value2) =
-  Anf.Select (anfValue TyBool condValue) (anfValue ty value1) (anfValue ty value2)
+  Anf.Select () (anfValue TyBool condValue) (anfValue ty value1) (anfValue ty value2)
 
-anfIcmp :: Ast.Icmp Range -> Anf.Icmp
+anfIcmp :: Ast.Icmp Range -> Anf.Icmp ()
 anfIcmp (Ast.Icmp _ (Ast.Cmp _ cmp) ty value1 value2) =
-  Anf.Icmp cmp (typeStr ty) (anfValue (typeStr ty) value1) (anfValue (typeStr ty) value2)
+  Anf.Icmp () cmp (typeStr ty) (anfValue (typeStr ty) value1) (anfValue (typeStr ty) value2)
 
-anfCall :: Ast.Call Range -> Anf.Call
+anfCall :: Ast.Call Range -> Anf.Call ()
 anfCall (Ast.Call _ _ name args) =
   let
     callee = nameToString name
     callArgs = anfCallArgs args
   in case intrinsicRewrite callee callArgs of
     Just call -> call
-    Nothing   -> Anf.Call (Anf.Name callee) callArgs
+    Nothing   -> Anf.Call () (Anf.Name () callee) callArgs
 
 -- | Rewrite the pure integer LLVM intrinsics clang emits at @-O1@ to their
 -- Prelude equivalents. Names arrive here already punctuation-stripped by
@@ -174,33 +179,33 @@ anfCall (Ast.Call _ _ name args) =
 -- normalized prefix. Only @llvm.*@ is rewritten; an ordinary same-module call
 -- yields 'Nothing' and falls through unchanged. @llvm.abs@'s second argument is
 -- the @i1@ poison immarg, which has no Haskell counterpart and is dropped.
-intrinsicRewrite :: String -> [Anf.Value] -> Maybe Anf.Call
+intrinsicRewrite :: String -> [Anf.Value ()] -> Maybe (Anf.Call ())
 intrinsicRewrite callee args
-  | "llvmabs"  `isPrefixOf` callee = Just (Anf.Call (Anf.Name "abs") (take 1 args))
-  | "llvmsmin" `isPrefixOf` callee = Just (Anf.Call (Anf.Name "min") args)
-  | "llvmsmax" `isPrefixOf` callee = Just (Anf.Call (Anf.Name "max") args)
+  | "llvmabs"  `isPrefixOf` callee = Just (Anf.Call () (Anf.Name () "abs") (take 1 args))
+  | "llvmsmin" `isPrefixOf` callee = Just (Anf.Call () (Anf.Name () "min") args)
+  | "llvmsmax" `isPrefixOf` callee = Just (Anf.Call () (Anf.Name () "max") args)
   | otherwise                      = Nothing
 
-anfBinOp :: Ast.BinOpCall Range -> Anf.BinOp
+anfBinOp :: Ast.BinOpCall Range -> Anf.BinOp ()
 anfBinOp (Ast.BinOpCall _ (Ast.BinOp _ binop) ty value1 value2) =
-  Anf.BinOp binop (anfValue (typeStr ty) value1) (anfValue (typeStr ty) value2)
+  Anf.BinOp () binop (anfValue (typeStr ty) value1) (anfValue (typeStr ty) value2)
 
-anfCallArgs :: [Ast.CallArgument Range] -> [Anf.Value]
+anfCallArgs :: [Ast.CallArgument Range] -> [Anf.Value ()]
 anfCallArgs = map anfCallArg
 
-anfCallArg :: Ast.CallArgument Range -> Anf.Value
+anfCallArg :: Ast.CallArgument Range -> Anf.Value ()
 anfCallArg (Ast.CallArgument _ ty value) = anfValue (typeStr ty) value
 
 -- | Translate an operand. The contextual 'Ty' (from the enclosing instruction's
 -- annotation) is only consulted for floating literals, which must be tagged so
 -- the printer emits @Float@\/@Double@ and an explicitly-typed literal; names and
 -- integer literals print the same regardless.
-anfValue :: Ty -> Ast.Value Range -> Anf.Value
+anfValue :: Ty -> Ast.Value Range -> Anf.Value ()
 -- An i1 literal (LLVM @true@\/@false@, lexed as 1\/0) is a 'Bool' in context.
-anfValue TyBool (Ast.ValueInt (Ast.IntegerValue _ int)) = Anf.BConst (int /= 0)
-anfValue _ (Ast.ValueInt (Ast.IntegerValue _ int)) = Anf.Const int
-anfValue _ (Ast.ValueName name) = Anf.Name (nameToString name)
-anfValue ty (Ast.ValueFloat (Ast.FloatValue _ txt)) = Anf.FConst txt ty
+anfValue TyBool (Ast.ValueInt (Ast.IntegerValue _ int)) = Anf.BConst () (int /= 0)
+anfValue _ (Ast.ValueInt (Ast.IntegerValue _ int)) = Anf.Const () int
+anfValue _ (Ast.ValueName name) = Anf.Name () (nameToString name)
+anfValue ty (Ast.ValueFloat (Ast.FloatValue _ txt)) = Anf.FConst () txt ty
 
-valueFromName :: Ast.Name Range -> Anf.Value
-valueFromName = Anf.Name . nameToString
+valueFromName :: Ast.Name Range -> Anf.Value ()
+valueFromName = Anf.Name () . nameToString

--- a/test/AnnotatedSpec.hs
+++ b/test/AnnotatedSpec.hs
@@ -1,0 +1,90 @@
+-- | Spec for docs/roadmap/plans/04-annotated-anf-ast.md: the annotated ANF AST
+-- and the backend seam. Because item 04 is a behaviour-preserving refactor, the
+-- assertions target the two theorems that pin it down rather than any new
+-- generated feature:
+--
+--   * T1 (annotation transparency / naturality, §2.4): the Haskell backend
+--     factors through annotation erasure — relabelling never changes its output.
+--   * T2 (pipeline factorisation, §2.4): inserting the (currently trivial)
+--     effect pass is observationally invisible on the Haskell backend.
+--
+-- plus the proof that the seam is real (a second backend that /reads/ the label
+-- the Haskell backend ignores) and that the effect lattice obeys its laws.
+module AnnotatedSpec (spec) where
+
+import Test.Hspec
+import qualified Data.ByteString.Lazy.Char8 as BL
+import Data.List (isInfixOf)
+
+import Lexer (runAlex)
+import Parser (parseLLVMIR)
+import Translate (translate)
+import qualified Anf
+import Effect (Effect(..), annotate)
+import Backend (render)
+import PrintAnf (printProgram, haskellBackend)
+import AnnotDump (annotDumpBackend, dumpProgram)
+
+-- | Parse a snippet to the bare (@()@-annotated) ANF term.
+parseAnf :: String -> Anf.Program ()
+parseAnf src = case runAlex (BL.pack src) parseLLVMIR of
+  Left err  -> error ("parse failed: " ++ err)
+  Right ast -> translate ast
+
+-- A loop with a φ-carried accumulator: exercises blocks, bindings, a conditional
+-- branch and tail calls — i.e. every node kind the annotation threads through.
+loopExample :: String
+loopExample = unlines
+  [ "define i32 @sum_to(i32 %n) {"
+  , "  br label %loop"
+  , "loop:"
+  , "  %acc = phi i32 [ 0, %0 ], [ %acc2, %loop ]"
+  , "  %i = phi i32 [ 0, %0 ], [ %i2, %loop ]"
+  , "  %acc2 = add i32 %acc, %i"
+  , "  %i2 = add i32 %i, 1"
+  , "  %c = icmp slt i32 %i2, %n"
+  , "  br i1 %c, label %loop, label %done"
+  , "done:"
+  , "  ret i32 %acc2"
+  , "}"
+  ]
+
+spec :: Spec
+spec = do
+  describe "annotated ANF / backend seam" $ do
+    let prog = parseAnf loopExample
+
+    describe "T1 — annotation transparency (Haskell backend ignores labels)" $ do
+      it "renders the annotated tree exactly as the bare tree" $
+        printProgram (annotate prog) `shouldBe` printProgram prog
+
+      it "is invariant under an arbitrary relabelling (naturality)" $
+        -- relabel every node to a String annotation; output must not move.
+        printProgram (fmap (const "X") prog) `shouldBe` printProgram prog
+
+      it "factors through erasure: render . erase = render" $
+        printProgram (Anf.erase (annotate prog)) `shouldBe` printProgram (annotate prog)
+
+    describe "T2 — pipeline factorisation (inserting the effect pass is inert)" $
+      it "new (render . annotate . translate) equals old (printProgram . translate)" $
+        render haskellBackend (annotate prog) `shouldBe` printProgram prog
+
+    describe "the seam is real — a second backend reads what Haskell ignores" $ do
+      it "produces output different from the Haskell backend on the same tree" $
+        render annotDumpBackend (annotate prog) `shouldNotBe` render haskellBackend (annotate prog)
+
+      it "surfaces the effect label that the Haskell backend never prints" $ do
+        dumpProgram (annotate prog) `shouldSatisfy` ("effect: Pure" `isInfixOf`)
+        printProgram (annotate prog) `shouldNotSatisfy` ("Pure" `isInfixOf`)
+
+    describe "effect baseline — the pure subset infers as effect-free" $
+      it "labels every node Pure (foldMap over the Foldable instance)" $
+        -- every annotation in the whole tree is the lattice bottom.
+        all (== Pure) (annotate prog) `shouldBe` True
+
+  describe "effect lattice laws (join-semilattice)" $ do
+    it "is associative" $
+      (Pure <> Pure) <> Pure `shouldBe` Pure <> (Pure <> Pure)
+    it "has mempty as identity" $ do
+      mempty <> Pure `shouldBe` Pure
+      Pure <> mempty `shouldBe` Pure

--- a/test/AnnotatedSpec.hs
+++ b/test/AnnotatedSpec.hs
@@ -10,11 +10,21 @@
 --
 -- plus the proof that the seam is real (a second backend that /reads/ the label
 -- the Haskell backend ignores) and that the effect lattice obeys its laws.
+--
+-- T1/T2 and the all-'Pure' baseline are checked twice: once corpus-wide over
+-- every @examples/*.ll@ (so every node kind the project accepts — calls,
+-- selects, conversions, freezes, floats, unit returns, … — is exercised), and
+-- once on a single readable in-line fixture that documents the properties
+-- self-containedly.
 module AnnotatedSpec (spec) where
 
 import Test.Hspec
-import qualified Data.ByteString.Lazy.Char8 as BL
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Lazy.Char8 as BLC
+import System.Directory (listDirectory)
+import System.FilePath ((</>), takeExtension)
 import Data.List (isInfixOf)
+import Control.Monad (forM_)
 
 import Lexer (runAlex)
 import Parser (parseLLVMIR)
@@ -27,12 +37,41 @@ import AnnotDump (annotDumpBackend, dumpProgram)
 
 -- | Parse a snippet to the bare (@()@-annotated) ANF term.
 parseAnf :: String -> Anf.Program ()
-parseAnf src = case runAlex (BL.pack src) parseLLVMIR of
+parseAnf src = case runAlex (BLC.pack src) parseLLVMIR of
   Left err  -> error ("parse failed: " ++ err)
   Right ast -> translate ast
 
--- A loop with a φ-carried accumulator: exercises blocks, bindings, a conditional
--- branch and tail calls — i.e. every node kind the annotation threads through.
+-- | Parse a corpus file to the bare ANF term.
+parseAnfFile :: FilePath -> IO (Anf.Program ())
+parseAnfFile path = do
+  s <- BL.readFile path
+  case runAlex s parseLLVMIR of
+    Left err  -> error ("parse failed for " ++ path ++ ": " ++ err)
+    Right ast -> return (translate ast)
+
+-- | Every @.ll@ under @examples/@ (the certified corpus).
+corpusFiles :: FilePath -> IO [FilePath]
+corpusFiles dir = do
+  entries <- listDirectory dir
+  return [ dir </> e | e <- entries, takeExtension e == ".ll" ]
+
+-- | The three annotation invariants, asserted on one program. Bundled so the
+-- corpus group stays one assertion per file.
+invariantsHold :: Anf.Program () -> Expectation
+invariantsHold prog = do
+  -- T1: the Haskell backend renders the annotated tree exactly as the bare one.
+  printProgram (annotate prog) `shouldBe` printProgram prog
+  -- T1, naturality: invariant under an *arbitrary* relabelling, not just Pure.
+  printProgram (fmap (const ("X" :: String)) prog) `shouldBe` printProgram prog
+  -- T2: new pipeline (render . annotate) == old pipeline (printProgram).
+  render haskellBackend (annotate prog) `shouldBe` printProgram prog
+  -- Baseline: the pure subset labels every node with the lattice bottom.
+  all (== Pure) (annotate prog) `shouldBe` True
+
+-- A representative function used for the readable, self-contained theorem checks:
+-- a φ-carried loop covering blocks, φ-args, arithmetic, an icmp, a conditional
+-- branch, tail calls and a return. Exhaustive node-kind coverage of T1/T2 comes
+-- from the corpus-wide group, not from this fixture.
 loopExample :: String
 loopExample = unlines
   [ "define i32 @sum_to(i32 %n) {"
@@ -51,7 +90,14 @@ loopExample = unlines
 
 spec :: Spec
 spec = do
-  describe "annotated ANF / backend seam" $ do
+  describe "T1/T2 hold corpus-wide (every accepted node kind)" $ do
+    files <- runIO (corpusFiles "examples")
+    forM_ files $ \path -> do
+      prog <- runIO (parseAnfFile path)
+      it ("preserves output and infers all-Pure: " ++ path) $
+        invariantsHold prog
+
+  describe "annotated ANF / backend seam (readable fixture)" $ do
     let prog = parseAnf loopExample
 
     describe "T1 — annotation transparency (Haskell backend ignores labels)" $ do
@@ -59,8 +105,7 @@ spec = do
         printProgram (annotate prog) `shouldBe` printProgram prog
 
       it "is invariant under an arbitrary relabelling (naturality)" $
-        -- relabel every node to a String annotation; output must not move.
-        printProgram (fmap (const "X") prog) `shouldBe` printProgram prog
+        printProgram (fmap (const ("X" :: String)) prog) `shouldBe` printProgram prog
 
       it "factors through erasure: render . erase = render" $
         printProgram (Anf.erase (annotate prog)) `shouldBe` printProgram (annotate prog)
@@ -76,11 +121,6 @@ spec = do
       it "surfaces the effect label that the Haskell backend never prints" $ do
         dumpProgram (annotate prog) `shouldSatisfy` ("effect: Pure" `isInfixOf`)
         printProgram (annotate prog) `shouldNotSatisfy` ("Pure" `isInfixOf`)
-
-    describe "effect baseline — the pure subset infers as effect-free" $
-      it "labels every node Pure (foldMap over the Foldable instance)" $
-        -- every annotation in the whole tree is the lattice bottom.
-        all (== Pure) (annotate prog) `shouldBe` True
 
   describe "effect lattice laws (join-semilattice)" $ do
     it "is associative" $


### PR DESCRIPTION
Implements roadmap item [#04 — Annotated ANF AST with multiple backends](docs/roadmap/04-annotated-anf-ast.md). Full design + theory in [`docs/roadmap/plans/04-annotated-anf-ast.md`](docs/roadmap/plans/04-annotated-anf-ast.md).

## What this is

A **refactor**, not a feature. It gives the output (ANF) AST a place to carry *derived* analysis results and turns the Haskell printer from *the* output into *one backend among several* — **without changing a single byte of emitted Haskell**.

Its entire value is structural: it is the seam that the two godmode research items both plug into — **#05** (effect inference: compute *where* effects live) and **#06** (monadic translation: emit effectful code *there*). The roadmap is explicit that #04 is "not valuable on its own"; this PR is the scaffolding those two stand on.

## Why it matters (impact)

- **Unblocks the two high-impact research items.** Before this, `Anf` had no annotation slot at any granularity and `PrintAnf` *was* the output. After it, #05 is a **body-only change** to `Effect.annotate` (+ a richer `Effect` lattice), and #06 is **one new `Backend` value** that reads the effect label — neither needs to touch `Anf`'s structure or `Translate`. That forward-compat contract is tested, not just asserted.
- **Cleaner formal story for the dissertation.** The translation `F` now produces a *decorated* term; backends are *algebras* over it; effect analysis is a label-relabelling; monadic emission is a second algebra. This is the vocabulary the paper's "ANF ≡ Moggi's computational λ-calculus" remark needs to become a construction.
- **A verified-refactor exemplar.** The change is proven behaviour-preserving by two small theorems (below) plus the differential harness — a reusable methodology for the riskier #05/#06 changes.

## What changed

- **`src/Anf.hs`** — every node gains an annotation type parameter `a` (uniform, mirroring `Ast a`), deriving `Functor`/`Foldable`. This buys label *erasure* (`fmap (const ())`), *relabelling*, and *aggregation* (`foldMap` — how #05's bottom-up effect join will be a one-liner) for free, with no hand-written traversals. `Ty` stays constructor data (it directs codegen; it is **not** folded into the annotation).
- **`src/Translate.hs`** — produces the bare `Anf.Program ()`.
- **`src/Effect.hs`** *(new)* — the `Effect` join-semilattice (`Pure`/⊥, lawful `Semigroup`/`Monoid`) and `annotate :: Program () -> Program Effect`, currently the constant-`Pure` baseline (which *is* #05's stated sanity milestone: the pure subset must infer effect-free).
- **`src/Backend.hs`** *(new)* — a backend is a record `{ backendName, render }`, so the backend menu is an ordinary heterogeneous value (no existential machinery).
- **`src/PrintAnf.hs`** — now annotation-blind (`printProgram :: Program a -> String`), exposed as `haskellBackend`.
- **`src/AnnotDump.hs`** *(new)* — a second backend that *reads* the label the Haskell backend ignores, proving the seam is real (and a debug aid for #05).
- **`app/Main.hs`** — pipeline is now `parse → translate → annotate → render`, with a `--backend NAME` flag.

## Verification

| Check | Result |
|---|---|
| Output vs `main` (gcd/prime/safe_div, direct diff) | byte-identical |
| Differential harness (24 functions) | all bit-for-bit exact |
| Full test suite | 70 examples, 0 failures |
| Build under full `-W` set | warning-clean |

`test/AnnotatedSpec.hs` encodes the refactor's oracle:
- **T1 — annotation transparency / naturality:** the Haskell backend factors through erasure; relabelling never changes output.
- **T2 — pipeline factorisation:** inserting the (trivial) effect pass is observationally inert on the Haskell backend.
- **Seam is real:** a second backend emits different text *and* surfaces the `Pure` label the Haskell backend never prints.
- **Pure baseline:** `all (== Pure)` over the derived `Foldable` instance.
- **Lattice laws:** associativity + identity for `Effect`.

## Notes for reviewers

- `llvm-ir-to-functional.cabal` is regenerated by hpack (auto-discovered new modules); `package.yaml` needs no edit.
- **Finding:** the `docs/{gcd,prime,safe_div}` golden `.hs` files differ from live output by one trailing blank line — *pre-existing on `main`*, not introduced here. So the trustworthy regression oracle is "diff against `main` output" + the differential harness, not the `docs/` goldens. Recorded in the roadmap item; worth regenerating those goldens separately.